### PR TITLE
Update hyper2000.py

### DIFF
--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -86,9 +86,6 @@ class Hyper2000(ZendureDevice):
             self.sensor("plugState"),
             self.sensor("pvBrand"),
             self.sensor("VoltWakeup", None, "V", "voltage", "measurement"),
-            self.sensor("ambientLightNess"),
-            self.sensor("ambientLightColor"),
-            self.sensor("ambientLightMode"),
             self.sensor("OldMode"),
             self.sensor("circuitCheckMode"),
             self.version("dspversion"),
@@ -97,6 +94,9 @@ class Hyper2000(ZendureDevice):
         ZendureSensor.add(sensors)
 
         self.nosensor(["invOutputPower"])
+        self.nosensor(["ambientLightNess"])
+        self.nosensor(["ambientLightColor"])
+        self.nosensor(["ambientLightMode"])
 
         selects = [
             self.select("acMode", {1: "input", 2: "output"}, self.update_ac_mode),


### PR DESCRIPTION
According to https://github.com/Zendure/developer-device-data-report the ambientlight refers to the SuperbaseV. I also see no ambientlight on the Hyper, so I think we should suppress these sensors.