### PR TITLE
Update device.py

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -347,8 +347,6 @@ class ZendureDevice(EntityDevice):
 
     async def power_get(self) -> int:
         """Get the current power."""
-        if not self.online or self.packInputPower.state is None or self.outputPackPower.state is None:
-            return 0
         self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
         if self.powerAct != 0:
             self.powerAct += self.solarInputPower.asInt


### PR DESCRIPTION
asInt handles already non availability (and return 0 in doubt).
Also if i.e. outputPackPower is not available due to no charge (after restart i.e. in log of https://github.com/Zendure/Zendure-HA/issues/598#issue-3305019441), actual implementation return 0, even if packInputPower show some values.