### PR TITLE
Update manager.py

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -133,6 +133,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         await EntityDevice.add_entities()
         self.api.Init(self.config_entry.data, mqtt)
         self.update_p1meter(data.get(CONF_P1METER, "sensor.power_actual"))
+        self.update_fusegroups()
 
     async def _async_update_data(self) -> None:
         _LOGGER.debug("Updating Zendure data")


### PR DESCRIPTION
At this point it seems too early to update the fuse groups.

It generates this error. But will be updated a little later again:

<img width="1169" height="492" alt="image" src="https://github.com/user-attachments/assets/223421f9-39d2-42b2-b3fd-480d0742c5a5" />

Solved issue #598 