### PR TITLE
Fix powerAct calculation: use outputHomePower

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -380,9 +380,13 @@ class ZendureDevice(EntityDevice):
 
     async def power_get(self) -> int:
         """Get the current power."""
-        if not self.online or self.outputHomePower.state is None or self.gridInputPower.state is None:
+        if not self.online or self.packInputPower.state is None or self.outputPackPower.state is None:
             return 0
-        self.powerAct = self.outputHomePower.asInt - self.gridInputPower.asInt
+        self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
+        if self.powerAct != 0:
+            self.powerAct += self.solarInputPower.asInt
+        elif self.powerAct == 0 and not self.outputHomePower.asInt is None:
+            self.powerAct = self.outputHomePower.asInt
         return self.powerAct
 
     @property
@@ -486,6 +490,8 @@ class ZendureZenSdk(ZendureDevice):
         self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
         if self.powerAct != 0:
             self.powerAct += self.solarInputPower.asInt
+        elif self.powerAct == 0 and not self.outputHomePower.asInt is None:
+            self.powerAct = self.outputHomePower.asInt
         return self.powerAct
 
     def power_set(self, state: ManagerState, power: int) -> int:

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -386,7 +386,7 @@ class ZendureDevice(EntityDevice):
         self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
         if self.powerAct != 0:
             self.powerAct += self.solarInputPower.asInt
-        elif self.powerAct == 0 and not self.outputHomePower.asInt is None:
+        elif self.powerAct == 0 and self.outputHomePower.asInt is not None:
             self.powerAct = self.outputHomePower.asInt
         return self.powerAct
 
@@ -491,7 +491,7 @@ class ZendureZenSdk(ZendureDevice):
         self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
         if self.powerAct != 0:
             self.powerAct += self.solarInputPower.asInt
-        elif self.powerAct == 0 and not self.outputHomePower.asInt is None:
+        elif self.powerAct == 0 and self.outputHomePower.asInt is not None:
             self.powerAct = self.outputHomePower.asInt
         return self.powerAct
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -114,6 +114,7 @@ class ZendureDevice(EntityDevice):
 
         self.electricLevel = ZendureSensor(self, "electricLevel", None, "%", "battery", "measurement")
         self.packInputPower = ZendureSensor(self, "packInputPower", None, "W", "power", "measurement")
+        self.outputHomePower = ZendureSensor(self, "outputHomePower", None, "W", "power", "measurement")
         self.outputPackPower = ZendureSensor(self, "outputPackPower", None, "W", "power", "measurement")
         self.solarInputPower = ZendureSensor(self, "solarInputPower", None, "W", "power", "measurement")
         self.hemsState = ZendureBinarySensor(self, "hemsState")

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -380,11 +380,9 @@ class ZendureDevice(EntityDevice):
 
     async def power_get(self) -> int:
         """Get the current power."""
-        if not self.online or self.packInputPower.state is None or self.outputPackPower.state is None:
+        if not self.online or self.outputHomePower.state is None or self.gridInputPower.state is None:
             return 0
-        self.powerAct = self.packInputPower.asInt - self.outputPackPower.asInt
-        if self.powerAct != 0:
-            self.powerAct += self.solarInputPower.asInt
+        self.powerAct = self.outputHomePower.asInt - self.gridInputPower.asInt
         return self.powerAct
 
     @property


### PR DESCRIPTION
use outputHomePower to add a "backup" value for the Actualpower for eatch device

