### PR TITLE
Bug-fixes for fusegroup, change of power_get() and power limit for smart charge

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -116,6 +116,7 @@ class ZendureDevice(EntityDevice):
         self.packInputPower = ZendureSensor(self, "packInputPower", None, "W", "power", "measurement")
         self.outputPackPower = ZendureSensor(self, "outputPackPower", None, "W", "power", "measurement")
         self.solarInputPower = ZendureSensor(self, "solarInputPower", None, "W", "power", "measurement")
+        self.gridInputPower = ZendureSensor(self, "gridInputPower", None, "W", "power", "measurement")
         self.outputHomePower = ZendureSensor(self, "outputHomePower", None, "W", "power", "measurement")
         self.hemsState = ZendureBinarySensor(self, "hemsState")
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -190,10 +190,10 @@ class ZendureDevice(EntityDevice):
 
         if power < 0:
             soc = self.socSet.asNumber
-            return 0 if level >= soc else self.kWh * 10 / -power * (soc - level)
+            return 0 if level >= soc else min(999, self.kWh * 10 / -power * (soc - level))
 
         soc = self.minSoc.asNumber
-        return 0 if level <= soc else self.kWh * 10 / power * (level - soc)
+        return 0 if level <= soc else min(999, self.kWh * 10 / power * (level - soc))
 
     async def entityWrite(self, entity: EntityZendure, value: Any) -> None:
         if entity.unique_id is None:

--- a/custom_components/zendure_ha/devices/solarflow2400ac.py
+++ b/custom_components/zendure_ha/devices/solarflow2400ac.py
@@ -19,9 +19,4 @@ class SolarFlow2400AC(ZendureZenSdk):
         self.powerMax = 2400
         self.gridOffPower = ZendureSensor(self, "gridOffPower", None, "W", "power", "measurement")
 
-    async def power_get(self) -> int:
-        """Get the current power."""
-        self.powerAct = await super().power_get()
-        if self.gridOffPower.state is not None:
-            self.powerAct -= self.gridOffPower.asInt
-        return self.powerAct
+

--- a/custom_components/zendure_ha/devices/solarflow800Pro.py
+++ b/custom_components/zendure_ha/devices/solarflow800Pro.py
@@ -19,9 +19,3 @@ class SolarFlow800Pro(ZendureZenSdk):
         self.powerMax = 2400
         self.gridOffPower = ZendureSensor(self, "gridOffPower", None, "W", "power", "measurement")
 
-    async def power_get(self) -> int:
-        """Get the current power."""
-        self.powerAct = await super().power_get()
-        if self.gridOffPower.state is not None:
-            self.powerAct -= self.gridOffPower.asInt
-        return self.powerAct

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -291,6 +291,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 if g is None:
                     continue
                 pwr = power * d.powerAvail / (maxPower if maxPower != 0 else 1)
+                # limit power to solar input if smart charge only is selected
+                if self.operation == SmartMode.MATCHING_CHARGE and d.solarInputPower.asNumber is not None:
+                    pwr = min(pwr, d.solarInputPower.asNumber)
 
                 # adjust the power for the fusegroup
                 pwr = int(max(g.powerAvail - g.powerUsed, pwr) if isCharging else min(g.powerAvail - g.powerUsed, pwr))

--- a/custom_components/zendure_ha/sensor.py
+++ b/custom_components/zendure_ha/sensor.py
@@ -61,8 +61,8 @@ class ZendureSensor(EntityZendure, SensorEntity):
             if self.factor != 1:
                 try:
                     # temporary fix for batcur
-                    if self.factor == CONS_BATCUR and int(new_value) > CONS_SIGN:
-                        new_value = ((value ^ 0x8000) - 0x8000) / self.factor
+                    if int(new_value) > CONS_SIGN:
+                        new_value = ((value ^ CONS_SIGN) - CONS_SIGN) / self.factor
                     else:
                         new_value = float(new_value) / self.factor
                 except ValueError:


### PR DESCRIPTION
Missing fusegroup added (should solve https://github.com/Zendure/Zendure-HA/issues/682#issuecomment-3216414688)
Change power_get(): Finally this calculates the power which goes in or out of the device. 
You can use outputHomePower and gridInputPower, or add all incoming or outgoing power like solarInputPower, packInputPower, outputPackPower, gridOffPower and so on.
This solution doesn't care on single values, just get the sum of in- or outgoing power. This will also cover any other DC output i.e. of the SuperBaseV6400
This needs to remove the additional subtract of gridOffPower for SF 800 pro and SF 2400AC (should solve #686, #646)
With this changes PR #689 is not necessary anymore)

Limited also the power to the solar input power, in case smart charge is selected (should solve #461)
Change in sensor.py, that all unsigned int will be converted to signed int. (should solve #690)
Also limit the remainingTime to 999h