### PR TITLE
Personalisierte Batterie Ladefenster

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -32,6 +32,7 @@ class DeviceState(Enum):
     INACTIVE = 3
     STARTING = 4
     ACTIVE = 5
+    MIN_SOC_CHARGE_WINDOW = 6
 
 
 class ManagerState(Enum):

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -21,7 +21,7 @@ from .binary_sensor import ZendureBinarySensor
 from .button import ZendureButton
 from .const import DeviceState, SmartMode
 from .entity import EntityDevice, EntityZendure
-from .number import ZendureNumber
+from .number import ZendureRestoreNumber, ZendureNumber
 from .select import ZendureRestoreSelect, ZendureSelect
 from .sensor import ZendureRestoreSensor, ZendureSensor
 
@@ -108,6 +108,7 @@ class ZendureDevice(EntityDevice):
         self.actualKwh: float = 0.0
         self.activeKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
+        self.min_soc_charge_window_ready = False
 
         self.create_entities()
 
@@ -115,12 +116,14 @@ class ZendureDevice(EntityDevice):
         """Create the device entities."""
         self.limitOutput = ZendureNumber(self, "outputLimit", self.entityWrite, None, "W", "power", 800, 0, NumberMode.SLIDER)
         self.limitInput = ZendureNumber(self, "inputLimit", self.entityWrite, None, "W", "power", 1200, 0, NumberMode.SLIDER)
-        self.minSoc = ZendureNumber(self, "minSoc", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10)
-        self.socSet = ZendureNumber(self, "socSet", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10)
+        self.minSoc = ZendureNumber(self, "minSoc", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10, icon="mdi:battery-10")
+        self.socSet = ZendureNumber(self, "socSet", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10, icon="mdi:battery")
         self.socStatus = ZendureSensor(self, "socStatus", state=0)
         self.socLimit = ZendureSensor(self, "socLimit", state=0)
         self.byPass = ZendureBinarySensor(self, "pass")
         self.gridReverse = ZendureSelect(self, "gridReverse", {0: "disabled", 1: "allow", 2: "forbidden"}, self.entityWrite, 0)
+        self.MSCW1 = ZendureRestoreNumber(self, "MSCW1", self.entityWrite, None, "%", "soc", 20, 0, NumberMode.SLIDER, 10, icon="mdi:battery-10")
+        self.MSCW2 = ZendureRestoreNumber(self, "MSCW2", self.entityWrite, None, "%", "soc", 20, 0, NumberMode.SLIDER, 10, icon="mdi:battery-10")
 
         fuseGroups = {0: "unused", 1: "owncircuit", 2: "group800", 3: "group1200", 4: "group2000", 5: "group2400", 6: "group3600"}
         self.fuseGroup = ZendureRestoreSelect(self, "fuseGroup", fuseGroups, None)
@@ -142,6 +145,8 @@ class ZendureDevice(EntityDevice):
         self.connectionStatus = ZendureSensor(self, "connectionStatus")
         self.connection: ZendureRestoreSelect
         self.remainingTime = ZendureSensor(self, "remainingTime", None, "h", "duration", "measurement")
+        self.MSCW1sensor = ZendureBinarySensor(self, "MSCW1sensor")
+        self.MSCW2sensor = ZendureBinarySensor(self, "MSCW2sensor")
 
     def setStatus(self) -> None:
         from .api import Api
@@ -432,12 +437,41 @@ class ZendureDevice(EntityDevice):
             self.lastseen = datetime.min
             self.setStatus()
 
+        min_soc = self.minSoc.asNumber
+        min_soc += 0 #only for testing
+        upper1 = min_soc + self.MSCW1.asNumber
+        upper2 = upper1 + self.MSCW1.asNumber
+
         if self.socSet.asNumber == 0 or self.kWh == 0:
             self.state = DeviceState.OFFLINE
         elif self.socLimit.asInt == SmartMode.SOCFULL or self.electricLevel.asInt >= self.socSet.asNumber:
             self.state = DeviceState.SOCFULL
-        elif self.socLimit.asInt == SmartMode.SOCEMPTY or self.electricLevel.asInt <= self.minSoc.asNumber:
+
+        elif self.electricLevel.asInt <= min_soc or self.socLimit.asInt == SmartMode.SOCEMPTY and (self.MSCW1.asNumber > 0 or self.MSCW2.asNumber > 0) and not self.min_soc_charge_window_ready:
             self.state = DeviceState.SOCEMPTY
+            self.min_soc_charge_window_ready = True
+            self.MSCW1sensor.update_value(True)
+            self.MSCW2sensor.update_value(False)
+
+        elif self.electricLevel.asNumber <= upper1 and self.MSCW1.asNumber != 0 and self.min_soc_charge_window_ready:
+            self.state = DeviceState.SOCEMPTY
+            self.MSCW1sensor.update_value(True)
+            self.MSCW2sensor.update_value(False)
+
+        elif self.electricLevel.asNumber <= upper2 and self.MSCW2.asNumber != 0 and self.min_soc_charge_window_ready:
+            self.state = DeviceState.MIN_SOC_CHARGE_WINDOW
+            self.MSCW1sensor.update_value(False)
+            self.MSCW2sensor.update_value(True)
+
+        elif self.electricLevel.asNumber > upper2 and self.MSCW2.asNumber != 0 and self.min_soc_charge_window_ready:
+            self.state = DeviceState.INACTIVE
+            self.min_soc_charge_window_ready = False
+            self.MSCW1sensor.update_value(False)
+            self.MSCW2sensor.update_value(False)
+
+        elif self.socLimit.asInt == SmartMode.SOCEMPTY or self.electricLevel.asNumber <= self.minSoc.asNumber:
+            self.state = DeviceState.SOCEMPTY
+
         else:
             self.state = DeviceState.INACTIVE if self.online else DeviceState.OFFLINE
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -440,7 +440,7 @@ class ZendureDevice(EntityDevice):
         min_soc = self.minSoc.asNumber
         min_soc += 0 #only for testing
         upper1 = min_soc + self.MSCW1.asNumber
-        upper2 = upper1 + self.MSCW1.asNumber
+        upper2 = upper1 + self.MSCW2.asNumber
 
         if self.socSet.asNumber == 0 or self.kWh == 0:
             self.state = DeviceState.OFFLINE

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -78,6 +78,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 10000, -10000, NumberMode.BOX, True)
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
         self.power = ZendureSensor(self, "power", None, "W", "power", None, 0)
+        self.p1_avg = ZendureSensor(self, "p1_avg", None, "W", "power", None, 0)
+        self.p1_stddev = ZendureSensor(self, "p1_stddev", None, "W", "power", None, 0)
+        self.p1_powerAverage = ZendureSensor(self, "p1_powerAverage", None, "W", "power", None, 0)
 
         # load devices
         for dev in data["deviceList"]:
@@ -196,6 +199,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             stddev = min(50, sqrt(sum([pow(i - avg, 2) for i in self.p1_history]) / len(self.p1_history)))
             if isFast := abs(p1 - avg) > SmartMode.Threshold * stddev:
                 self.p1_history.clear()
+            self.p1_avg.update_value(avg)
+            self.p1_stddev.update_value(stddev)
         else:
             isFast = False
         self.p1_history.append(p1)
@@ -230,6 +235,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.power.update_value(power)
         self.availableKwh.update_value(availEnergy)
         powerAverage = sum(self.power_history) // len(self.power_history) if len(self.power_history) > 0 else 0
+        self.p1_powerAverage.update_value(powerAverage)
 
         # Callback to update power distribution
         async def powerUpdate(power: int, zero: bool = False) -> None:
@@ -330,6 +336,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         self.total = 0
         self.devices = sorted(self.devices, key=sortDevices, reverse=True)
+        self.devices = sorted(self.devices, key=lambda d: d.state == DeviceState.MIN_SOC_CHARGE_WINDOW) #put this devices at the end of sorting
 
         if self.total > SmartMode.START_POWER:
             _LOGGER.info(f"powerDischarge => {power}W average {average}W, total {self.total}W")
@@ -353,8 +360,10 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     starting -= d.startDischarge
 
             flexPwr = max(0, power - totalMin - solar)
+            maxsolpwr = sum(d.actualSolar for d in self.devices if d.state == DeviceState.MIN_SOC_CHARGE_WINDOW)
 
         for d in self.devices:
+            _LOGGER.info(f"State => {d.name}W average {d.state}W")
             match d.state:
                 case DeviceState.ACTIVE:
                     pwr = min(d.maxDischarge - d.minDischarge, int(flexPwr * (d.maxDischarge * d.actualKwh / totalWeight if totalWeight > 0 else 0)))
@@ -364,6 +373,10 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     power -= d.power_discharge(min(power, pwr) + d.actualSolar)
                 case DeviceState.STARTING:
                     d.power_discharge(SmartMode.STARTWATT + d.actualSolar)
+                case DeviceState.MIN_SOC_CHARGE_WINDOW:
+                    pwr = power * d.actualSolar / (maxsolpwr if maxsolpwr != 0 else 1)
+                    maxsolpwr -= d.actualSolar
+                    d.power_discharge(max(0, min(d.actualSolar, pwr)))
                 case DeviceState.OFFLINE:
                     continue
                 case _:

--- a/custom_components/zendure_ha/number.py
+++ b/custom_components/zendure_ha/number.py
@@ -38,6 +38,7 @@ class ZendureNumber(EntityZendure, NumberEntity):
         mode: NumberMode = NumberMode.AUTO,
         factor: int = 1,
         doupdate: bool = False,
+        icon: str | None = None,
     ) -> None:
         """Initialize a number entity."""
         super().__init__(device, uniqueid, "number")
@@ -46,6 +47,7 @@ class ZendureNumber(EntityZendure, NumberEntity):
             name=uniqueid,
             native_unit_of_measurement=uom,
             device_class=deviceclass,
+            icon=icon,
         )
 
         self._value_template: Template | None = template
@@ -117,9 +119,10 @@ class ZendureRestoreNumber(ZendureNumber, RestoreEntity):
         minimum: int = 0,
         mode: NumberMode = NumberMode.AUTO,
         doupdate: bool = False,
+        icon: str | None = None,
     ) -> None:
         """Initialize a number entity."""
-        super().__init__(device, uniqueid, onwrite, template, uom, deviceclass, maximum, minimum, mode, 1, doupdate)
+        super().__init__(device, uniqueid, onwrite, template, uom, deviceclass, maximum, minimum, mode, 1, doupdate, icon=icon)
         self._attr_native_value = 0
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -65,6 +65,12 @@
       },
       "hems_state": {
         "name": "HEMS-Status"
+      },
+      "m_s_c_w1sensor": {
+        "name": "Batterie Lade Fenster 1"
+      },
+      "m_s_c_w2sensor": {
+        "name": "Batterie Lade Fenster 2"
       }
     },
     "number": {
@@ -82,6 +88,12 @@
       },
       "soc_set": {
         "name": "SoC-Maximum"
+      },
+      "m_s_c_w1": {
+        "name": "SoC-Minimum-Fenster-1"
+      },
+      "m_s_c_w2": {
+        "name": "SoC-Minimum-Fenster-2"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -65,6 +65,12 @@
       },
       "hems_state": {
         "name": "HEMS State"
+      },
+      "m_s_c_w1sensor": {
+        "name": "Battery Charge Window 1"
+      },
+      "m_s_c_w2sensor": {
+        "name": "Battery Charge Window 2"
       }
     },
     "number": {
@@ -82,6 +88,12 @@
       },
       "soc_set": {
         "name": "SoC Maximum"
+      },
+      "m_s_c_w1": {
+        "name": "SoC-Minimum Window 1"
+      },
+      "m_s_c_w2": {
+        "name": "SoC-Minimum Window 2"
       }
     },
     "sensor": {


### PR DESCRIPTION
Personalisierte Ladefenster (relativ zum Min-SoC)
Zwei Fenster steuern strikt das Verhalten zwischen Tiefentladung und Schonbetrieb.

Fenster 1 – Priorisiertes Schnellladen
Aktivierung: sofort bei Erreichen von Min-SoC.
Bereich: Min-SoC → Min-SoC + Fenster 1.
Verhalten: Batterie gilt als praktisch leer und wird mit maximal möglicher Leistung geladen.
Zweck: Schneller Ausstieg aus Tiefentladung.

Fenster 2 – Haus priorisieren (Batterieschonung)
Umschaltung: ab Min-SoC + Fenster 1 (nur wenn Fenster 2 > 0).
Bereich: (Min-SoC + Fenster 1) → (Min-SoC + Fenster 1 + Fenster 2).
Verhalten: Keine Entladung der Batterie; Laden nur mit Überschussenergie.
Zweck: Zyklen vermeiden, besonders bei schlechtem Wetter.

Steuerung
Zwei Slider pro Gerät.
Slider = 0 → Fenster aus.
Beide = 0 → Standardverhalten wie bisher.
Binary-Sensoren zeigen aktives Fenster.

Formel
Obergrenze Fenster 1 = Min-SoC + Fenster 1
Obergrenze Fenster 2 = Min-SoC + Fenster 1 + Fenster 2

Beispiel
Min-SoC: 5 %
Fenster 1: 10 % → aktiv 5 %–15 %
Fenster 2: 10 % → aktiv 15 %–25 %

Merke: Fenster-Prozente sind Aufschläge über Min-SoC → Min-SoC + Fenster 1 + Fenster 2.

Zendure-Manager Ergänzungen
Power-Entitäten: Standardabweichung, P1-Durchschnitt, Power-Durchschnitt (für HA-Diagramme).

Batterie-Icons an Min/Max-SoC-Steuerelementen.

![Screenshot_2025-09-15-20-53-00-030_io homeassistant companion android](https://github.com/user-attachments/assets/ecbaf9a5-533e-4798-92c9-d7604ac75da9)
