### PR TITLE
Add condition to power discharge logic

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -454,7 +454,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
                     setpoint = min(0, setpoint - pwr)
 
-                elif average < d.pwr_load or isFirst:
+                elif (average < d.pwr_load or isFirst) and abs(setpoint) > 0:
                     await d.power_discharge(SmartMode.STARTWATT) if d.pwr_produced < -SmartMode.STARTWATT else await d.power_charge(-SmartMode.STARTWATT)
                 else:
                     await d.power_discharge(0 if issurplus else -d.pwr_produced)


### PR DESCRIPTION
It makes no sense to start a device if setpoint == 0. Without this change, a single device with no PV direct connect always load 40W if set to Smart Charge only