### PR TITLE
Fix power bypass calculation for SOCFULL state

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -356,7 +356,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         for d in self.devices:
             if await d.power_get():
                 availEnergy += d.availableKwh.asNumber
-                pwr_bypass += d.pwr_home if d.state == DeviceState.SOCFULL else 0
+                pwr_bypass += -d.pwr_home if d.state == DeviceState.SOCFULL else 0
                 pwr_home += d.pwr_home
                 pwr_produced += d.pwr_produced
                 devices.append(d)


### PR DESCRIPTION
The real bypass power is the outputHomePower
<img width="1880" height="646" alt="image" src="https://github.com/user-attachments/assets/5712455c-1e3e-4cc3-bb89-e031c9b87ab1" />
