### PR TITLE
Added AB2000X model identifier

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -51,7 +51,7 @@ class ZendureBattery(EntityDevice):
                 model = "AB1000S"
                 self.kWh = 0.96
             case "C":
-                model = "AB2000" + ("S" if sn[3] == "F" else "")
+                model = "AB2000" + ("S" if sn[3] == "F" else "X" if sn[3] == "E" else "")
                 self.kWh = 1.92
             case "F":
                 model = "AB3000"


### PR DESCRIPTION
Added identification for AB2000X. I can confirm the "E" as the fourth position of the serial number with the SolarFlow 800 Pro integrated AB2000X and in issue #801 the E is confirmed as well.