### PR TITLE
New hems status

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -315,6 +315,7 @@ class ZendureDevice(EntityDevice):
                 case "properties/energy":
                     self.hemsState.update_value(1)
                     self.hemsStateUpdated = datetime.now()
+                    self.setStatus()
                     return True
 
                 # case "firmware/report":


### PR DESCRIPTION
ZenSDK devices seems to get the properties/energy topics as MQTT from the cloud.