### PR TITLE
Fix power charge and change trigger for switchcount

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -185,14 +185,13 @@ class ZendureDevice(EntityDevice):
         try:
             if changed:
                 match key:
-                    case "outputPackPower":
+                    case "packState":
                         if value == 0:
                             self.aggrSwitchCount.update_value(1 + self.aggrSwitchCount.asNumber)
+                    case "outputPackPower":
                         self.aggrCharge.aggregate(dt_util.now(), value)
                         self.aggrDischarge.aggregate(dt_util.now(), 0)
                     case "packInputPower":
-                        if value == 0:
-                            self.aggrSwitchCount.update_value(1 + self.aggrSwitchCount.asNumber)
                         self.aggrCharge.aggregate(dt_util.now(), 0)
                         self.aggrDischarge.aggregate(dt_util.now(), value)
                     case "solarInputPower":


### PR DESCRIPTION
- power and charge_limit are negative, so max is necessary to avoid full power charging
- setting the device to idle, switches OFF the output relais