### PR TITLE
Add configurable solar grid input start and tolerance numbers

### DIFF
--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -79,6 +79,12 @@
       },
       "soc_set": {
         "name": "SoC-Maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Solar Netzeinspeisung Start"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Solar Netzeinspeisung Toleranz"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -79,6 +79,12 @@
       },
       "soc_set": {
         "name": "SoC Maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Solar GridInput Start"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Solar GridInput Tolerance"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -84,6 +84,12 @@
       },
       "soc_set": {
         "name": "SOC maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Début injection solaire réseau"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Tolérance injection solaire réseau"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -80,6 +80,12 @@
       },
       "soc_set": {
         "name": "SOC Maximaal"
+      },
+      "solar_grid_input_start": {
+        "name": "Start zonne-invoer net"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Tolerantie zonne-invoer net"
       }
     },
     "sensor": {


### PR DESCRIPTION
This PR adds two new Number entities to make the previously hardcoded SmartMode thresholds configurable:

- solar_grid_input_start: controls SmartMode.POWER_START (min 25W, max 5000W)
- solar_grid_input_tolerance: controls SmartMode.POWER_TOLERANCE (min 5W, max start-10W)

The values are persisted (RestoreNumber) and applied at startup. The tolerance range auto-updates when the start value changes.

UI labels were added to translations (en/de/fr/nl).
