### PR TITLE
Add configurable solar grid input start and tolerance numbers

### DIFF
--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -79,6 +79,12 @@
       },
       "soc_set": {
         "name": "SoC-Maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Solar Netzeinspeisung Start"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Solar Netzeinspeisung Toleranz"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -79,6 +79,12 @@
       },
       "soc_set": {
         "name": "SoC Maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Solar GridInput Start"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Solar GridInput Tolerance"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -84,6 +84,12 @@
       },
       "soc_set": {
         "name": "SOC maximum"
+      },
+      "solar_grid_input_start": {
+        "name": "Début injection solaire réseau"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Tolérance injection solaire réseau"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -80,6 +80,12 @@
       },
       "soc_set": {
         "name": "SOC Maximaal"
+      },
+      "solar_grid_input_start": {
+        "name": "Start zonne-invoer net"
+      },
+      "solar_grid_input_tolerance": {
+        "name": "Tolerantie zonne-invoer net"
       }
     },
     "sensor": {


### PR DESCRIPTION
### Summary

This PR introduces two new `number` entities to make previously hardcoded `SmartMode` thresholds configurable:

- `solar_grid_input_start` → controls `SmartMode.POWER_START` (**min 25W**, **max 5000W**)
- `solar_grid_input_tolerance` → controls `SmartMode.POWER_TOLERANCE` (**min 5W**, **max start - 10W**)

Both values are persisted via `RestoreNumber` and applied automatically on startup. The tolerance entity range updates dynamically whenever the start value changes.

UI labels/translations were added for **en/de/fr/nl**.

---

### How the new entities override the previous hardcoded defaults

Previously, the integration relied on static defaults in `const.py`:

- `SmartMode.POWER_START = 50`
- `SmartMode.POWER_TOLERANCE = 5`

These constants are referenced across the codebase:
- `manager.py` uses `SmartMode.POWER_START` for “start / kick-off” behavior (e.g., starting idle devices and enabling discharge of produced power).
- `device.py` uses `SmartMode.POWER_TOLERANCE` as the device-level deadband in `power_charge()` / `power_discharge()` (skip updates when the delta is within tolerance).

This PR adds two new persistent (`RestoreNumber`) manager-level entities:

- `number.*_solar_grid_input_start` → updates `SmartMode.POWER_START`
- `number.*_solar_grid_input_tolerance` → updates `SmartMode.POWER_TOLERANCE`

#### Runtime behavior
- On integration startup, `const.py` still provides *fallback defaults* (50W / 5W).
- The new number entities are created and initialized with these defaults.
- When Home Assistant restores the last saved entity states (`RestoreEntity`), the restored values are applied via the entity callbacks:
  - `update_power_start(...)` sets `SmartMode.POWER_START`
  - `update_power_tolerance(...)` sets `SmartMode.POWER_TOLERANCE`

As a result, the thresholds are no longer effectively hardcoded at runtime—they are overridden by the persisted HA entity values.

#### Constraints / clamping
- `solar_grid_input_start`: **25W … 5000W**
- `solar_grid_input_tolerance`: **5W … (start - 10W)**
  - The tolerance entity range is updated automatically when the start value changes.
  - If tolerance exceeds the allowed maximum, it is clamped and the entity state is updated to remain consistent.

#### Why keep the constants in `const.py`?
They serve as safe defaults for fresh installs (no restored state yet) and avoid refactoring all existing call sites that reference `SmartMode.POWER_START` / `SmartMode.POWER_TOLERANCE`.
