### PR TITLE
Fix invalid entity ID error in HA 2026.02

### DIFF
--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -41,7 +41,6 @@ class EntityZendure(Entity):
             return
         self.device = device
         self._attr_unique_id = f"{self.device.name}-{uniqueid}"
-        self.entity_id = f"{entitytype}.{self.device.name}-{snakecase(uniqueid)}"
         self._attr_translation_key = snakecase(uniqueid)
         device.entities[uniqueid] = self
 


### PR DESCRIPTION
## Error

When using device names with spaces, for each entity there is an error like this:

```
Traceback (most recent call last):
File "/workspaces/ha-core/homeassistant/helpers/entity_platform.py", line 679, in _async_add_entities
await self._async_add_entity(
entity, False, entity_registry, config_subentry_id
)
File "/workspaces/ha-core/homeassistant/helpers/entity_platform.py", line 826, in _async_add_entity
raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
homeassistant.exceptions.HomeAssistantError: Invalid entity ID: switch.SolarFlow 800 Pro-lamp_switch
```

## Root Cause

Manually construction of entity ids worked until [HA PR #160302](https://github.com/home-assistant/core/pull/160302), which tightens entity id validation where it previously auto-corrected such ids.

## Fix

Removal of the manual entity_id assignment  works . since the entity already sets `_attr_has_entity_name = True`, leading Home Assistant to  automatically generate valid entity IDs with proper sanitization using the unique_id and device information.