### PR TITLE
Update German translations for power limits

### DIFF
--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -69,10 +69,10 @@
     },
     "number": {
       "input_limit": {
-        "name": "Eingangslimit"
+        "name": "Eingangsleistung"
       },
       "output_limit": {
-        "name": "Ausgangslimit"
+        "name": "Ausgangsleistung"
       },
       "manual_power": {
         "name": "Manuelle Leistung"
@@ -296,7 +296,7 @@
         "name": "Hardware-Version"
       },
       "inverse_max_power": {
-        "name": "Wechselrichtereingangsleistung"
+        "name": "behördl. begrenzte Ausgangsleistung"
       },
       "grid_power": {
         "name": "Netzleistung"


### PR DESCRIPTION
Three translations have been adjusted because they regularly caused confusion. The input and output “limits” are not actual limits, but power values expressed in watts (W) which u can use when zendure manager is "off".

Plus third one: Wechselrichtereingangsleistung is the official regulation value which u define in the zendure app and give the max. values which the device should for max. output to home.