### PR TITLE
Log exception name when handling HTTP API call errors

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -625,7 +625,7 @@ class ZendureZenSdk(ZendureDevice):
             self.lastseen = datetime.now()
             return payload if key is None else payload.get(key, {})
         except Exception as e:
-            _LOGGER.error(f"HttpGet error {self.name} {e}!")
+            _LOGGER.error(f"{type(e).__name__} for {self.name} during httpGet{f': {e}' if str(e) else '!'}")
             self.lastseen = datetime.min
         return {}
 
@@ -637,7 +637,7 @@ class ZendureZenSdk(ZendureDevice):
             url = f"http://{self.ipAddress}/{url}"
             await self.session.post(url, json=command, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
         except Exception as e:
-            _LOGGER.error(f"HttpPost error {self.name} {e}!")
+            _LOGGER.error(f"{type(e).__name__} for {self.name} during httpPost{f': {e}' if str(e) else '!'}")
             self.lastseen = datetime.min
             return False
         return True


### PR DESCRIPTION
Hi,

I was noticing some error messages in my Home Assistant log that weren't that helpful, especially if `str(e)` is empty:

```
ERROR (MainThread) [custom_components.zendure_ha.device] HttpGet error SolarFlow 800 Pro !
```

This changes addresses this by logging the name of the actual exception. And if available, also the data as before. Example:

```
ERROR (MainThread) [custom_components.zendure_ha.device] TimeoutError for SolarFlow 800 Pro during httpGet!
```

On that note, I get a couple of these timeouts since https://github.com/Zendure/Zendure-HA/commit/353f35086491e21ae3d81cfafeb732edc6b3fe55. Most likely due to Wifi congestion. Though no response times were >10 seconds. Response times are normally within 50ms.

