### PR TITLE
Update version to 1.2.5 in manifest.json

### DIFF
--- a/custom_components/zendure_ha/manifest.json
+++ b/custom_components/zendure_ha/manifest.json
@@ -17,5 +17,5 @@
     "stringcase==1.2.0"
   ],
   "single_config_entry": true,
-  "version": "1.0.0"
+  "version": "1.2.5"
 }


### PR DESCRIPTION
should always show latest version plus optional small infos - why 1.0.0 back?