### PR TITLE
feat: add max_battery_output_power sensor to ZendureManager

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -101,6 +101,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 12000, -12000, NumberMode.BOX, True)
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
         self.power = ZendureSensor(self, "power", None, "W", "power", "measurement", 0)
+        self.max_battery_output_power = ZendureSensor(self, "max_battery_output_power", None, "W", "power", "measurement", 0)
 
         # load devices
         for dev in data["deviceList"]:
@@ -234,6 +235,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 for d in fg.devices:
                     d.fuseGrp = fg
                 self.fuseGroups.append(fg)
+                
+        self.max_battery_output_power.update_value(sum(min(sum(d.discharge_limit for d in fg.devices if d.kWh > 0), fg.maxpower) for fg in self.fuseGroups))
 
     async def update_operation(self, entity: ZendureSelect, _operation: Any) -> None:
         operation = ManagerMode(entity.value)
@@ -440,6 +443,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         # Update the power entities
         self.power.update_value(power)
         self.availableKwh.update_value(availableKwh)
+        self.max_battery_output_power.update_value(sum(min(sum(d.discharge_limit for d in fg.devices if d.kWh > 0), fg.maxpower) for fg in self.fuseGroups))
         if self.discharge_bypass > setpoint:
             setpoint -= self.discharge_bypass
 

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -239,6 +239,9 @@
       "power": {
         "name": "Leistung"
       },
+      "max_battery_output_power": {
+        "name": "Maximale Batterieausgangsleistung"
+      },
       "pass": {
         "name": "Bypass",
         "state": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -242,6 +242,9 @@
       "power": {
         "name": "Power"
       },
+      "max_battery_output_power": {
+        "name": "Maximum Battery Output Power"
+      },
       "pass": {
         "name": "Bypass",
         "state": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -235,6 +235,9 @@
       "power": {
         "name": "Puissance"
       },
+      "max_battery_output_power": {
+        "name": "Puissance maximale cumulée des batteries"
+      },
       "pass": {
         "name": "Dérivation ( bypass )",
         "state": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -227,6 +227,9 @@
       "pack_input_power": {
         "name": "Batterij Ontladen"
       },
+      "max_battery_output_power": {
+        "name": "Maximum Batterij Uitgangsvermogen"
+      },
       "output_pack_power": {
         "name": "Batterij Laden"
       },


### PR DESCRIPTION
This pull request introduces a new `max_battery_output_power` sensor to the Zendure integration.

### Need
The purpose of this sensor is to provide the actual total discharge capacity of the setup, considering both hardware limits and fuse group constraints. This allows users to:
- **Calculate battery utilization percentage:** By comparing current power output to this maximum value, users can create informative dashboards or widgets showing how much of their discharge capacity is being used.
- **Accurate monitoring:** The sensor dynamically updates based on the current configuration, including when devices are added or removed from fuse groups.

### Key Changes
- **New Sensor:** Added `max_battery_output_power` to `ZendureManager`.
- **Intelligent Calculation:**
  - Sums the hardware discharge limits of all connected devices with batteries (`kWh > 0`).
  - Caps the sum for each fuse group by its `maxpower` configuration.
  - Aggregates the results across all fuse groups.
- **Dynamic Updates:** The sensor value is refreshed when fuse groups change or during regular manager updates.
- **Translations:** Added support for English, German, French, and Dutch.