### PR TITLE
feat: add total_kwh sensor to expose installed battery capacity

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -137,6 +137,7 @@ class ZendureDevice(EntityDevice):
         self.hemsState = ZendureBinarySensor(self, "hemsState")
         self.hemsStateUpdate = datetime.min
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
         self.connectionStatus = ZendureSensor(self, "connectionStatus")
         self.connection: ZendureRestoreSelect
         self.remainingTime = ZendureSensor(self, "remainingTime", None, "h", "duration", "measurement")
@@ -308,13 +309,17 @@ class ZendureDevice(EntityDevice):
 
                 if (bat := self.batteries.get(sn, None)) is None:
                     self.batteries[sn] = ZendureBattery(self.hass, sn, self)
-                    self.kWh = sum(0 if b is None else b.kWh for b in self.batteries.values())
-                    self.availableKwh.update_value((self.electricLevel.asNumber - self.minSoc.asNumber) / 100 * self.kWh)
 
                 elif bat and b:
                     for key, value in b.items():
                         if key != "sn":
                             bat.entityUpdate(key, value)
+
+            # Recalculate total capacity after every packData update
+            # (covers both new batteries and potential pack changes)
+            self.kWh = sum(0 if b is None else b.kWh for b in self.batteries.values())
+            self.totalKwh.update_value(self.kWh)
+            self.availableKwh.update_value((self.electricLevel.asNumber - self.minSoc.asNumber) / 100 * self.kWh)
 
     def mqttMessage(self, topic: str, payload: Any) -> bool:
         try:

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -100,6 +100,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.operationstate = ZendureSensor(self, "operation_state")
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 12000, -12000, NumberMode.BOX, True)
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
         self.power = ZendureSensor(self, "power", None, "W", "power", "measurement", 0)
 
         # load devices
@@ -440,6 +441,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         # Update the power entities
         self.power.update_value(power)
         self.availableKwh.update_value(availableKwh)
+        self.totalKwh.update_value(sum(d.kWh for d in self.devices))
         if self.discharge_bypass > setpoint:
             setpoint -= self.discharge_bypass
 

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -91,6 +91,9 @@
       "available_kwh": {
         "name": "Verfügbare Energie"
       },
+      "total_kwh": {
+        "name": "Gesamtkapazität Batterie"
+      },
       "auto_model": {
         "name": "Energieplan",
         "state": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -91,6 +91,9 @@
       "available_kwh": {
         "name": "Available Energy"
       },
+      "total_kwh": {
+        "name": "Total Battery Capacity"
+      },
       "auto_model": {
         "name": "Battery Program",
         "state": {


### PR DESCRIPTION
## Summary

This PR adds a new `total_kwh` sensor to every Zendure device and the Zendure Manager, exposing the **total installed battery capacity** (in kWh at 100% SoC) as a Home Assistant entity.

### Problem

Currently, `self.kWh` — the sum of all connected battery pack capacities, derived from serial number prefixes in `ZendureBattery.__init__` — is calculated internally but **never exposed to Home Assistant**. The only existing kWh-related sensor is `available_kwh`, which represents the *currently usable* energy:

```
available_kwh = (electricLevel% - minSoc%) / 100 × total_kWh
```

This makes it impossible to display or use total installed capacity in dashboards, energy cards, or automations without custom template sensors.

### Solution

Add `sensor.*_total_kwh` to each device and `sensor.zendure_manager_total_kwh` to the manager.

**Battery capacity values used (from `ZendureBattery.__init__`, by SN prefix):**

| SN prefix | Model | Capacity |
|-----------|-------|----------|
| `C` | AB2000 / AB2000S / AB2000X | 1.92 kWh |
| `F` | AB3000 | 2.88 kWh |
| `J` | AB3000L | 2.88 kWh |
| `A` (sn[3]≠3) | AB1000 | 0.96 kWh |
| `A` (sn[3]=3) | AIO2400 | 2.4 kWh |
| `B` | AB1000S | 0.96 kWh |

### Changes

**`device.py`**
- Add `self.totalKwh = ZendureSensor(self, "total_kwh", ...)` in `create_entities()`
- Move `self.kWh` recalculation **outside** the `if bat is None` block so it runs on every `packData` MQTT message, not only when a new battery SN is first seen. This also fixes a subtle bug: if batteries change between MQTT messages, `self.kWh` now always reflects the current connected set.
- Call `self.totalKwh.update_value(self.kWh)` and consolidate `self.availableKwh.update_value(...)` alongside it.

**`manager.py`**
- Add `self.totalKwh = ZendureSensor(self, "total_kwh", ...)` in `__init__()`
- Update it in `powerChanged()` as `sum(d.kWh for d in self.devices)` — aggregate total capacity across all managed devices.

**`translations/en.json`** — add `"total_kwh": { "name": "Total Battery Capacity" }`

**`translations/de.json`** — add `"total_kwh": { "name": "Gesamtkapazität Batterie" }`

### New entities

| Entity ID | Description |
|-----------|-------------|
| `sensor.<device>_total_kwh` | Total installed capacity for that device (e.g. `3.84 kWh` for a Hyper2000 with 2× AB2000S) |
| `sensor.zendure_manager_total_kwh` | Aggregate total capacity across all devices |

### Compatibility

All device types (`ZendureLegacy` and `ZendureZenSdk`) inherit from `ZendureDevice` and do **not** override `mqttProperties`, so this change applies automatically to all supported devices: Hyper2000, SolarFlow 800/1600/2400, Hub1200/2000, ACE1500, AIO2400, SuperBase V.

### Diff size

4 files changed, 15 insertions(+), 2 deletions(-)