### PR TITLE
fix the device not responding to changes of the acMode after renaming the ids

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -255,7 +255,7 @@ class ZendureDevice(EntityDevice):
 
         _LOGGER.info(f"Writing property {self.name} {entity.name} => {value}")
         self._messageid += 1
-        property_name = entity.translation_key.replace("_", "")
+        property_name = getattr(entity, "command_key", entity.translation_key.replace("_", ""))
         payload = json.dumps(
             {
                 "deviceId": self.deviceId,
@@ -584,7 +584,7 @@ class ZendureZenSdk(ZendureDevice):
         if self.online and self.connection.value == 0:
             await super().entityWrite(entity, value)
         else:
-            property_name = entity.translation_key.replace("_", "")
+            property_name = getattr(entity, "command_key", entity.translation_key.replace("_", ""))
             _LOGGER.info(f"Writing property {self.name} {property_name} => {value}")
             await self.httpPost("properties/write", {"properties": {property_name: value}})
 

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -42,6 +42,8 @@ class EntityZendure(Entity):
         self._attr_unique_id = snakecase(f"{self.device.name.lower()}_{uniqueid}").replace("__", "_")
         self.internal_integration_suggested_object_id = self._attr_unique_id
         self._attr_translation_key = snakecase(uniqueid)
+        # Keep the original key for write commands (for example acMode vs ac_mode).
+        self.command_key = uniqueid
         device.entities[uniqueid] = self
 
     @property


### PR DESCRIPTION
I wasn't able to charge my Hyper in the new release by using "off" mode, and the device didn't seem to respond to changes to the acMode.
Using negative values on manual mode made the device charge, but the acMode inexplicably reverted to output (after manually changing them to input).
This should fix both issues.