### PR TITLE
feat: weight power distribution by battery capacity (kWh)

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -421,7 +421,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge.append(d)
                     self.charge_limit += d.fuseGrp.charge_limit(d)
                     self.charge_optimal += d.charge_optimal
-                    self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
+                    self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt) * max(d.kWh, 1.0)
                     setpoint += home
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
@@ -430,7 +430,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced
-                    self.discharge_weight += d.pwr_max * d.electricLevel.asInt
+                    self.discharge_weight += d.pwr_max * d.electricLevel.asInt * max(d.kWh, 1.0)
                     setpoint += home
 
                 else:
@@ -510,8 +510,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         limit = self.charge_limit
         setpoint = max(limit, setpoint)
         for i, d in enumerate(sorted(self.charge, key=lambda d: d.electricLevel.asInt, reverse=True)):
-            pwr = int(setpoint * (d.pwr_max * (100 - d.electricLevel.asInt)) / self.charge_weight)
-            self.charge_weight -= d.pwr_max * (100 - d.electricLevel.asInt)
+            pwr = int(setpoint * (d.pwr_max * (100 - d.electricLevel.asInt) * max(d.kWh, 1.0)) / self.charge_weight)
+            self.charge_weight -= d.pwr_max * (100 - d.electricLevel.asInt) * max(d.kWh, 1.0)
 
             # adjust the limit, make sure we have 'enough' power to charge
             limit -= d.pwr_max
@@ -561,9 +561,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         setpoint = min(limit, setpoint)
         for i, d in enumerate(sorted(self.discharge, key=lambda d: d.electricLevel.asInt, reverse=False)):
             # calculate power to discharge
-            if (pwr := int(setpoint * (d.pwr_max * d.electricLevel.asInt) / self.discharge_weight)) < -d.pwr_produced and d.state == DeviceState.SOCFULL:
+            if (pwr := int(setpoint * (d.pwr_max * d.electricLevel.asInt * max(d.kWh, 1.0)) / self.discharge_weight)) < -d.pwr_produced and d.state == DeviceState.SOCFULL:
                 pwr = -d.pwr_produced
-            self.discharge_weight -= d.pwr_max * d.electricLevel.asInt
+            self.discharge_weight -= d.pwr_max * d.electricLevel.asInt * max(d.kWh, 1.0)
 
             # adjust the limit, make sure we have 'enough' power to discharge
             limit -= -d.pwr_produced if solaronly else d.pwr_max


### PR DESCRIPTION
## Problem

When mixing batteries of different capacities (e.g. SolarFlow 2400AC with 17 kWh and Hyper 2000 with 4 kWh), the power distribution is unfair. The current weight formula `pwr_max * SOC` ignores total energy capacity, so a 17 kWh battery only receives ~56% of discharge power despite holding ~73% of the total stored energy.

This has been reported in #806 and #1084.

## Solution

Multiply the distribution weight by `max(d.kWh, 1.0)` so that larger batteries receive proportionally more charge/discharge power.

**New formula:** `weight = pwr_max × SOC × max(kWh, 1.0)`

6 lines changed in `manager.py`:
- `powerChanged()` — weight accumulation for charge and discharge
- `power_charge()` — per-device power calculation and weight decrement
- `power_discharge()` — per-device power calculation and weight decrement

## Backward compatibility

| Scenario | Behavior |
|---|---|
| Same-capacity batteries | kWh factor cancels out → **no change** |
| Single battery | Weight ratio is always 100% → **no change** |
| kWh not yet known (0.0) | Fallback `max(0.0, 1.0) = 1.0` → **original behavior** |
| Physical power limits | Still enforced via `min(pwr, d.pwr_max)` / `max(pwr, d.pwr_max)` caps |

## Test results

Tested on a real setup with 3 batteries (SolarFlow 2400AC 17 kWh + 2× Hyper 2000 4 kWh):

| Battery | Before | After |
|---|---|---|
| SolarFlow 2400AC (17 kWh, 71% SOC) | 0.89 kW (56%) | 1.56 kW (93%) |
| Hyper 2000 (4 kWh, 56% SOC) | 0.35 kW (22%) | 0.12 kW (7%) |
| Hyper 2000 2 (4 kWh, 55% SOC) | 0.34 kW (22%) | idle |

The larger battery now carries the bulk of the discharge, which is the expected behavior given its much higher stored energy. Peak power limits (2400W / 1200W) are still respected.