### PR TITLE
Solves Error from https://github.com/Zendure/Zendure-HA/issues/1209

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -148,9 +148,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         # initialize the api & p1 meter
         self.api.Init(self.config_entry.data, mqtt)
+        await self.update_fusegroups()
         self.update_p1meter(self.config_entry.data.get(CONF_P1METER, "sensor.power_actual"))
         await asyncio.sleep(1)  # allow other tasks to run
-        await self.update_fusegroups()
 
     async def update_fusegroups(self) -> None:
         _LOGGER.info("Update fusegroups")


### PR DESCRIPTION
Occurs after every reload. The device does not yet have a fuseGrp attribute when the first P1 event arrives because update_fusegroups() has not run yet. After the third reload, the error no longer occurs because the execution order happens to align by chance. This is a race condition. Change the method call to avoid this error.

await self.update_fusegroups() from Line 153 > Line 151

Solves Error from https://github.com/Zendure/Zendure-HA/issues/1209