### PR TITLE
Change state_class for HA-entity total_kwh / energy to "total_increasing"

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -143,7 +143,7 @@ class ZendureDevice(EntityDevice):
         self.hemsState = ZendureBinarySensor(self, "hemsState")
         self.hemsStateUpdate = datetime.min
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "total_increasing", 2)
         self.connectionStatus = ZendureSensor(self, "connectionStatus")
         self.connection: ZendureRestoreSelect
         self.bleAdapter: ZendureRestoreSelect | None = None

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -100,7 +100,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.operationstate = ZendureSensor(self, "operation_state")
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 12000, -12000, NumberMode.BOX, True)
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "total_increasing", 2)
         self.power = ZendureSensor(self, "power", None, "W", "power", "measurement", 0)
 
         # load devices


### PR DESCRIPTION
Shows on every reload. The state class should be total or total_increasing instead of measurement. This is an entity configuration error.

`Entity sensor.zendure_manager_total_kwh is using state class 'measurement' 
which is impossible considering device class ('energy')`