### PR TITLE
Fix division by zero in power_charge and power_discharge

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -510,8 +510,18 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         limit = self.charge_limit
         setpoint = max(limit, setpoint)
         for i, d in enumerate(sorted(self.charge, key=lambda d: d.electricLevel.asInt, reverse=True)):
-            pwr = int(setpoint * (d.pwr_max * (100 - d.electricLevel.asInt)) / self.charge_weight)
-            self.charge_weight -= d.pwr_max * (100 - d.electricLevel.asInt)
+            # Weight per device: pwr_max * remaining capacity (100 - SOC%).
+            # Devices with lower SOC get a larger share of the charge power.
+            # Guard against division by zero: charge_weight can be 0 when all
+            # remaining devices are at 100% SOC (nothing left to charge) or when
+            # it drops to 0 mid-iteration after subtracting previous devices.
+            device_weight = d.pwr_max * (100 - d.electricLevel.asInt)
+            if self.charge_weight != 0:
+                pwr = int(setpoint * device_weight / self.charge_weight)
+            else:
+                # all remaining devices at 100% SOC — skip charging
+                pwr = 0
+            self.charge_weight -= device_weight
 
             # adjust the limit, make sure we have 'enough' power to charge
             limit -= d.pwr_max
@@ -560,10 +570,23 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         limit = self.discharge_produced if solaronly else self.discharge_limit
         setpoint = min(limit, setpoint)
         for i, d in enumerate(sorted(self.discharge, key=lambda d: d.electricLevel.asInt, reverse=False)):
-            # calculate power to discharge
-            if (pwr := int(setpoint * (d.pwr_max * d.electricLevel.asInt) / self.discharge_weight)) < -d.pwr_produced and d.state == DeviceState.SOCFULL:
+            # Weight per device: pwr_max * SOC%. Devices with higher SOC get a
+            # larger share of the discharge power.
+            # Guard against division by zero: discharge_weight can be 0 when all
+            # remaining devices are at 0% SOC, or when it drops to 0 mid-iteration.
+            # In that case, distribute the remaining setpoint evenly across the
+            # remaining devices so they can still pass through solar production.
+            device_weight = d.pwr_max * d.electricLevel.asInt
+            if self.discharge_weight != 0:
+                pwr = int(setpoint * device_weight / self.discharge_weight)
+            elif len(self.discharge) > i:
+                pwr = int(setpoint / (len(self.discharge) - i))
+            else:
+                pwr = 0
+            # SOCFULL devices should only pass through solar, not drain battery
+            if pwr < -d.pwr_produced and d.state == DeviceState.SOCFULL:
                 pwr = -d.pwr_produced
-            self.discharge_weight -= d.pwr_max * d.electricLevel.asInt
+            self.discharge_weight -= device_weight
 
             # adjust the limit, make sure we have 'enough' power to discharge
             limit -= -d.pwr_produced if solaronly else d.pwr_max


### PR DESCRIPTION
I don't have multiple SolarFlows, so please verify this code, if related issues are fixed with that.

**Summary**

Charge_weight and discharge_weight in ZendureManager can become zero when devices reach 100% or 0% SOC, or when the accumulated weight drops to zero mid-iteration — causing a ZeroDivisionError that crashes the entire power distribution loop.

For charging (power_charge): when charge_weight == 0, all remaining devices are at 100% SOC — set pwr = 0 to skip charging.

For discharging (power_discharge): when discharge_weight == 0, distribute the remaining setpoint evenly across remaining devices so they can still pass through solar production                                                          
                                                                                                                                                                                                                                              
**Root cause** 

power_charge (line 513) and power_discharge (line 564) compute a weighted power share per device:                                                                                                                                           
   
`pwr = int(setpoint * (d.pwr_max * (100 - d.electricLevel.asInt)) / self.charge_weight)`                                                                                                                                                  
                  
When all devices in the loop have electricLevel == 100 (charge) or electricLevel == 0 (discharge), the weight sum is 0 and the division crashes. The exception is caught by the outer try/except in _p1_changed, which aborts the entire distribution cycle — leaving devices in their previous state and causing repeated start/stop cycling.
                                                                                                                                                                                                                                              **Related issues**  

possibly fixes #1203 — Smart power distribution not working at 100% SOC                                                                                                                                                                              
possibly fixes #1199 — All devices start and stop when batteries are full
possibly fixes #1135 — Constant switches between Idle and Discharge                                                                                                                                                                                  
possibly fixes #1140 — Fusegroup output limit not respected (partially)                                                                                                                                                                              
                                                                                                                                                                                                                                              
**Test plan** 

- [ ] Verify with multiple devices at 100% SOC: no crash, devices stay idle instead of cycling                                                                                                                                                  
- [ ] Verify with multiple devices at 0% SOC during discharge: power distributed evenly, no crash
- [ ] Verify normal operation (mixed SOC levels) still distributes power weighted by SOC as before                                                                                                                                              
- [ ] Verify SOCFULL devices still pass through solar production correctly                                                                                                                                                                      
- [ ] Verify fuse group limits are still respected during distribution