### PR TITLE
Fix/offgrid consumer power on discharge-path causes incorrect zero-feed-in setpoint

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -617,10 +617,13 @@ class ZendureDevice(EntityDevice):
     async def power_discharge(self, power: int) -> int:
         """Set discharge power."""
         power = max(0, min(power, self.discharge_limit))
-        if abs(power - self.homeOutput.asInt + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
+        offgrid = max(0, self.pwr_offgrid)
+        actual = min(power + offgrid, self.discharge_limit)
+        if abs(actual - self.homeOutput.asInt - offgrid + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
             _LOGGER.info(f"Power discharge {self.name} => no action [power {power}]")
             return self.homeOutput.asInt
-        return await self.discharge(power)
+        await self.discharge(actual)
+        return power
 
     async def power_off(self) -> None:
         """Set the power off."""

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -424,14 +424,14 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
                     setpoint += -d.homeInput.asInt  # use gridInputPower directly; offgrid consumers are invisible to P1
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
-                elif (home := d.homeOutput.asInt) > 0:
+                elif (home := d.homeOutput.asInt + max(0, d.pwr_offgrid)) > 0:
                     self.discharge.append(d)
                     self.discharge_bypass -= d.pwr_produced if d.state == DeviceState.SOCFULL else 0
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced
                     self.discharge_weight += d.pwr_max * d.electricLevel.asInt
-                    setpoint += home
+                    setpoint += d.homeOutput.asInt  # use outputHomePower directly; offgrid consumers are invisible to P1
 
                 else:
                     self.idle.append(d)


### PR DESCRIPTION
# Context
The SF2400AC has two outputs: AC (outputHomePower, P1-visible) and Off-Grid (gridOffPower, P1-invisible).
Bug 1: The device is classified as IDLE in discharge mode when only Off-Grid is active.
Bug 2: outputLimit does not compensate for gridOffPower,
as a result, almost all of the discharge power goes to the Off-Grid output instead of into the home network.

## Changes

Change 1 — manager.py Line 427 (Bug 1) 

### Original:
`elif (home := d.homeOutput.asInt) > 0:`

### Change:
`elif (home := d.homeOutput.asInt + max(0, d.pwr_offgrid)) > 0:`

Change 2 — manager.py Line 434 (Bug 2)

### Original:
`setpoint += home`

### Change:
`setpoint += d.homeOutput.asInt  # use outputHomePower directly; offgrid consumers are invisible to P1`

Change 3 — device.py Line 617-623 (Bug 2)

Das Kernproblem: Wenn der Manager power_discharge(130) aufruft, sendet das Gerät outputLimit=130. Das Gerät legt aber ~130W auf Off-Grid und ~0W auf Home. Der Manager muss outputLimit = gewünschte_home + gridOffPower senden.

### Original (Lines 617-623):
```
async def power_discharge(self, power: int) -> int:
    """Set discharge power."""
    power = max(0, min(power, self.discharge_limit))
    if abs(power - self.homeOutput.asInt + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
        _LOGGER.info(f"Power discharge {self.name} => no action [power {power}]")
        return self.homeOutput.asInt
    return await self.discharge(power)
```
### Change:
```
async def power_discharge(self, power: int) -> int:
    """Set discharge power."""
    power = max(0, min(power, self.discharge_limit))
    offgrid = max(0, self.pwr_offgrid)
    actual = min(power + offgrid, self.discharge_limit)
    if abs(actual - self.homeOutput.asInt - offgrid + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
        _LOGGER.info(f"Power discharge {self.name} => no action [power {power}]")
        return self.homeOutput.asInt
    await self.discharge(actual)
    return power
```
### Logic:
- power = needed Home-power for zero-feedin (P1-Matching)
- offgrid = current Off-Grid-Power 
- actual = power + offgrid = combined value for outputLimit
- min(..., discharge_limit) = Clamp to device-limits (2400W)
- Tolerance-Check compare actual with homeOutput + offgrid (= current discharge)
- Return power (not actual) → Manager subtracts only Home-power from setpoint

### Example with real Values:
- Manager demands 130W Home-power: power_discharge(130)
- offgrid = 135 → actual = 130 + 135 = 265
- device outputLimit = 265
- Device feedin: ~135W Off-Grid + ~130W Home
- P1 → ~0W

Devices without Off-Grid: offgrid = 0 → actual = power + 0 = power → identical behaviors as before.

## Not changed
- Line 442 (power += d.pwr_offgrid + home + d.pwr_produced): Only Monitoring-Sensor.
- Charge-Path: fixed by PR #1208.