### PR TITLE
refactor(logging): use lazy %-formatting in _LOGGER calls

### DIFF
--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -176,19 +176,19 @@ class Api:
             result = await session.post(url=f"{api_url}/api/ha/deviceList", json=body, headers=headers)
             data = await result.json()
             if data.get("code") != 200:
-                _LOGGER.debug(f"Zendure API response: {data.get('code')} Message: {data.get('msg')}")
+                _LOGGER.debug("Zendure API response: %s Message: %s", data.get("code"), data.get("msg"))
             elif data.get("code") == 200 and len(data["data"]["deviceList"]) == 0:
-                _LOGGER.error(f"Zendure API does not reply any devices: {data}")
+                _LOGGER.error("Zendure API does not reply any devices: %s", data)
                 return None
             elif data.get("code") == 200 and len(data["data"]["mqtt"]) == 0:
-                _LOGGER.error(f"Zendure API does not reply any mqtt info: {data}")
+                _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
                 return None
             if not data.get("success", False) or (result := data["data"]) is None:
                 return None
             return dict(result)
 
         except Exception as e:
-            _LOGGER.error(f"Unable to connect to Zendure {e}!")
+            _LOGGER.error("Unable to connect to Zendure %s!", e)
             _LOGGER.error(traceback.format_exc())
             return None
 
@@ -202,10 +202,10 @@ class Api:
             client.connect(srv, int(port))
             client.loop_start()
         except Exception as e:
-            _LOGGER.error(f"Unable to connect to Zendure {e}!")
+            _LOGGER.error("Unable to connect to Zendure %s!", e)
 
     def mqttConnect(self, client: Any, userdata: Any, _flags: Any, rc: Any, _props: Any) -> None:
-        _LOGGER.info(f"Client {userdata} connected to MQTT broker, return code: {rc}")
+        _LOGGER.info("Client %s connected to MQTT broker, return code: %s", userdata, rc)
         if userdata == "zendure":
             for device in self.devices.values():
                 if client == device.zendure:
@@ -218,7 +218,7 @@ class Api:
                 client.subscribe(f"iot/{device.prodkey}/{device.deviceId}/#")
 
     def mqttDisconnect(self, _client: Any, userdata: Any, _flags: Any, rc: Any, _props: Any) -> None:
-        _LOGGER.info(f"Client {userdata} disconnected to MQTT broker, return code: {rc}")
+        _LOGGER.info("Client %s disconnected to MQTT broker, return code: %s", userdata, rc)
 
     def mqttMsgCloud(self, client: Any, _userdata: Any, msg: Any) -> None:
         if msg.payload is None or not msg.payload:

--- a/custom_components/zendure_ha/binary_sensor.py
+++ b/custom_components/zendure_ha/binary_sensor.py
@@ -47,6 +47,6 @@ class ZendureBinarySensor(EntityZendure, BinarySensorEntity):
             if self.hass and self.hass.loop.is_running():
                 self.schedule_update_ha_state()
         except Exception as err:
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
 
         return True

--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -125,7 +125,7 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
                     if await Api.Connect(self.hass, self._user_input, False) is None:
                         errors["base"] = "invalid input"
                 except Exception as err:  # pylint: disable=broad-except
-                    _LOGGER.error(f"Unexpected exception: {err}")
+                    _LOGGER.error("Unexpected exception: %s", err)
                     errors["base"] = f"invalid input {err}"
                 else:
                     await self.async_set_unique_id("Zendure", raise_on_progress=False)

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -175,7 +175,7 @@ class ZendureDevice(EntityDevice):
             self.discharge_start = discharge // 10
             self.limitOutput.update_range(0, discharge)
         except Exception:
-            _LOGGER.error(f"SetLimits error {self.name} {charge} {discharge}!")
+            _LOGGER.error("SetLimits error %s %s %s!", self.name, charge, discharge)
 
     def setStatus(self) -> None:
         from .api import Api
@@ -241,7 +241,7 @@ class ZendureDevice(EntityDevice):
                             self.nextCalibration.update_value(dt_util.now() + timedelta(days=30))
                         self.availableKwh.update_value((self.electricLevel.asNumber - self.minSoc.asNumber) / 100 * self.kWh)
         except Exception as e:
-            _LOGGER.error(f"EntityUpdate error {self.name} {key} {e}!")
+            _LOGGER.error("EntityUpdate error %s %s %s!", self.name, key, e)
             _LOGGER.error(traceback.format_exc())
 
         return changed
@@ -263,10 +263,10 @@ class ZendureDevice(EntityDevice):
 
     async def entityWrite(self, entity: EntityZendure, value: Any) -> None:
         if entity.translation_key is None:
-            _LOGGER.error(f"Entity {entity.name} has no translation_key, cannot write property {self.name}")
+            _LOGGER.error("Entity %s has no translation_key, cannot write property %s", entity.name, self.name)
             return
 
-        _LOGGER.info(f"Writing property {self.name} {entity.propertyName} => {value}")
+        _LOGGER.info("Writing property %s %s => %s", self.name, entity.propertyName, value)
         self._messageid += 1
         payload = json.dumps(
             {
@@ -340,7 +340,7 @@ class ZendureDevice(EntityDevice):
                     # self.mqttProperties(payload)
 
                 case "register/replay":
-                    _LOGGER.info(f"Register replay for {self.name} => {payload}")
+                    _LOGGER.info("Register replay for %s => %s", self.name, payload)
                     if self.mqtt is not None:
                         self.mqtt.publish(f"iot/{self.prodkey}/{self.deviceId}/register/replay", None, 1, True)
 
@@ -360,7 +360,7 @@ class ZendureDevice(EntityDevice):
                     return False
 
                 # case "firmware/report":
-                #     _LOGGER.info(f"Firmware report for {self.name} => {payload}")
+                #     _LOGGER.info("Firmware report for %s => %s", self.name, payload)
                 case _:
                     return False
         except Exception as err:
@@ -378,7 +378,7 @@ class ZendureDevice(EntityDevice):
             elif self.connection.value == 1:
                 await self.bleMqtt(Api.mqttLocal)
 
-        _LOGGER.debug(f"Mqtt selected {self.name}")
+        _LOGGER.debug("Mqtt selected %s", self.name)
 
     @property
     def bleMac(self) -> str | None:
@@ -437,7 +437,7 @@ class ZendureDevice(EntityDevice):
                     if source := self._scanner_source(scanner_device):
                         sources.add(source)
         except Exception as err:
-            _LOGGER.debug(f"Could not read bluetooth scanner sources for {self.name}: {err}")
+            _LOGGER.debug("Could not read bluetooth scanner sources for %s: %s", self.name, err)
 
         # Fallback: derive sources from all discovered connectable advertisements.
         try:
@@ -446,7 +446,7 @@ class ZendureDevice(EntityDevice):
                     if source := getattr(info, "source", None):
                         sources.add(str(source))
         except Exception as err:
-            _LOGGER.debug(f"Could not derive bluetooth sources for {self.name}: {err}")
+            _LOGGER.debug("Could not derive bluetooth sources for %s: %s", self.name, err)
 
         return sorted(sources)
 
@@ -460,7 +460,7 @@ class ZendureDevice(EntityDevice):
                     if device := self._scanner_ble_device(scanner_device):
                         return device
             except Exception as err:
-                _LOGGER.debug(f"Could not get BLE device for {self.name} on source {source}: {err}")
+                _LOGGER.debug("Could not get BLE device for %s on source %s: %s", self.name, source, err)
 
         return None
 
@@ -510,7 +510,7 @@ class ZendureDevice(EntityDevice):
                 return False
 
             try:
-                _LOGGER.info(f"Set mqtt {self.name} to {mqtt.host}")
+                _LOGGER.info("Set mqtt %s to %s", self.name, mqtt.host)
                 if establish_connection is not None:
                     client = await establish_connection(BleakClient, device, self.name)
                 else:
@@ -580,10 +580,10 @@ class ZendureDevice(EntityDevice):
             payload = json.dumps(command, default=lambda o: o.__dict__)
             b = bytearray()
             b.extend(map(ord, payload))
-            _LOGGER.info(f"BLE command: {self.name} => {payload}")
+            _LOGGER.info("BLE command: %s => %s", self.name, payload)
             await client.write_gatt_char(SF_COMMAND_CHAR, b, response=False)
         except Exception as err:
-            _LOGGER.warning(f"BLE error: {err}")
+            _LOGGER.warning("BLE error: %s", err)
 
     async def power_get(self) -> bool:
         if self.lastseen < datetime.now():
@@ -611,7 +611,7 @@ class ZendureDevice(EntityDevice):
         """Set charge power."""
         power = min(0, max(power, self.charge_limit))
         if abs(power - self.homeInput.asInt + self.homeOutput.asInt) <= SmartMode.POWER_TOLERANCE:
-            _LOGGER.info(f"Power charge {self.name} => no action [power {power}]")
+            _LOGGER.info("Power charge %s => no action [power %s]", self.name, power)
             return self.homeInput.asInt
         return await self.charge(power)
 
@@ -623,7 +623,7 @@ class ZendureDevice(EntityDevice):
         """Set discharge power."""
         power = max(0, min(power, self.discharge_limit))
         if abs(power - self.homeOutput.asInt + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
-            _LOGGER.info(f"Power discharge {self.name} => no action [power {power}]")
+            _LOGGER.info("Power discharge %s => no action [power %s]", self.name, power)
             return self.homeOutput.asInt
         return await self.discharge(power)
 
@@ -661,7 +661,7 @@ class ZendureLegacy(ZendureDevice):
 
         match button.translation_key:
             case "mqtt_reset":
-                _LOGGER.info(f"Resetting MQTT for {self.name}")
+                _LOGGER.info("Resetting MQTT for %s", self.name)
                 await self.bleMqtt(Api.mqttCloud if self.connection.value == 0 else Api.mqttLocal)
 
     async def dataRefresh(self, _update_count: int) -> None:
@@ -676,7 +676,7 @@ class ZendureLegacy(ZendureDevice):
 
     def mqttMessage(self, topic: str, payload: Any) -> bool:
         if topic == "register/replay":
-            _LOGGER.info(f"Register replay for {self.name} => {payload}")
+            _LOGGER.info("Register replay for %s => %s", self.name, payload)
             return True
 
         return super().mqttMessage(topic, payload)
@@ -705,17 +705,17 @@ class ZendureZenSdk(ZendureDevice):
                 Api.mqttCloud.unsubscribe(f"/{self.prodkey}/{self.deviceId}/#")
                 Api.mqttCloud.unsubscribe(f"iot/{self.prodkey}/{self.deviceId}/#")
 
-        _LOGGER.debug(f"Mqtt selected {self.name}")
+        _LOGGER.debug("Mqtt selected %s", self.name)
 
     async def entityWrite(self, entity: EntityZendure, value: Any) -> None:
         if entity.translation_key is None:
-            _LOGGER.error(f"Entity {entity.name} has no translation_key, cannot write property {self.name}")
+            _LOGGER.error("Entity %s has no translation_key, cannot write property %s", entity.name, self.name)
             return
 
         if self.online and self.connection.value == 0:
             await super().entityWrite(entity, value)
         else:
-            _LOGGER.info(f"Writing property {self.name} {entity.propertyName} => {value}")
+            _LOGGER.info("Writing property %s %s => %s", self.name, entity.propertyName, value)
             await self.httpPost("properties/write", {"properties": {entity.propertyName: value}})
 
     async def dataRefresh(self, update_count: int) -> None:
@@ -733,12 +733,12 @@ class ZendureZenSdk(ZendureDevice):
 
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
         return power
 
@@ -760,7 +760,7 @@ class ZendureZenSdk(ZendureDevice):
             self.lastseen = datetime.now()
             return payload if key is None else payload.get(key, {})
         except Exception as e:
-            _LOGGER.error(f"{type(e).__name__} for {self.name} during httpGet{f': {e}' if str(e) else '!'}")
+            _LOGGER.error("%s for %s during httpGet%s", type(e).__name__, self.name, f": {e}" if str(e) else "!")
             self.lastseen = datetime.min
         return {}
 
@@ -772,7 +772,7 @@ class ZendureZenSdk(ZendureDevice):
             url = f"http://{self.ipAddress}/{url}"
             await self.session.post(url, json=command, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
         except Exception as e:
-            _LOGGER.error(f"{type(e).__name__} for {self.name} during httpPost{f': {e}' if str(e) else '!'}")
+            _LOGGER.error("%s for %s during httpPost%s", type(e).__name__, self.name, f": {e}" if str(e) else "!")
             self.lastseen = datetime.min
             return False
         return True

--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -22,7 +22,7 @@ class ACE1500(ZendureLegacy):
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [
@@ -44,7 +44,7 @@ class ACE1500(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [

--- a/custom_components/zendure_ha/devices/aio2400.py
+++ b/custom_components/zendure_ha/devices/aio2400.py
@@ -20,11 +20,11 @@ class AIO2400(ZendureLegacy):
         self.maxSolar = -1200
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"No AC charge for {self.name} available")
+        _LOGGER.info("No AC charge for %s available", self.name)
         return 0
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [

--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -25,7 +25,7 @@ class Hub1200(ZendureLegacy):
             self.limitInput.update_range(0, abs(self.powerMin))
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [{"autoModelProgram": 2, "autoModelValue": power, "msgType": 1, "autoModel": 8}],
@@ -35,7 +35,7 @@ class Hub1200(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [{"autoModelProgram": 2, "autoModelValue": power, "msgType": 1, "autoModel": 8}],

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -25,7 +25,7 @@ class Hub2000(ZendureLegacy):
         self.limitInput.update_range(0, abs(self.powerMin))
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [{"autoModelProgram": 2, "autoModelValue": power, "msgType": 1, "autoModel": 8}],
@@ -35,7 +35,7 @@ class Hub2000(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [{"autoModelProgram": 2, "autoModelValue": power, "msgType": 1, "autoModel": 8}],

--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -21,7 +21,7 @@ class Hyper2000(ZendureLegacy):
         self.maxSolar = -1600
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [
@@ -45,7 +45,7 @@ class Hyper2000(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [

--- a/custom_components/zendure_ha/devices/superbasev4600.py
+++ b/custom_components/zendure_ha/devices/superbasev4600.py
@@ -22,7 +22,7 @@ class SuperBaseV4600(ZendureLegacy):
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [
@@ -44,7 +44,7 @@ class SuperBaseV4600(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [

--- a/custom_components/zendure_ha/devices/superbasev6400.py
+++ b/custom_components/zendure_ha/devices/superbasev6400.py
@@ -22,7 +22,7 @@ class SuperBaseV6400(ZendureLegacy):
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
 
     async def charge(self, power: int) -> int:
-        _LOGGER.info(f"Power charge {self.name} => {power}")
+        _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [
@@ -44,7 +44,7 @@ class SuperBaseV6400(ZendureLegacy):
         return power
 
     async def discharge(self, power: int) -> int:
-        _LOGGER.info(f"Power discharge {self.name} => {power}")
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
         self.mqttInvoke(
             {
                 "arguments": [

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -62,7 +62,7 @@ class EntityZendure(Entity):
         self._attr_should_poll = False
         self._attr_available = True
         if device is None:
-            _LOGGER.warning(f"Entity {uniqueid} has no device, skipping initialization.")
+            _LOGGER.warning("Entity %s has no device, skipping initialization.", uniqueid)
             return
         self.device = device
         self.propertyName = uniqueid
@@ -283,7 +283,7 @@ class EntityDevice:
                         tmpl = Template(info[1], self.hass)
                         entity = ZendureSensor(self, key, tmpl, info[2], info[3], "measurement", None)
                     case _:
-                        _LOGGER.debug(f"Create sensor {self.name} {key} with no unit")
+                        _LOGGER.debug("Create sensor %s %s with no unit", self.name, key)
             else:
                 entity = ZendureSensor(self, key)
 
@@ -301,7 +301,7 @@ class EntityDevice:
         return
 
     def updateVersion(self, version: str) -> None:
-        _LOGGER.info(f"Updating {self.name} software version from {self.attr_device_info.get('sw_version')} to {version}")
+        _LOGGER.info("Updating %s software version from %s to %s", self.name, self.attr_device_info.get("sw_version"), version)
         device_registry = dr.async_get(self.hass)
         identifier = self.sn if self.sn else self.name
         device_entry = device_registry.async_get_device(identifiers={(DOMAIN, identifier)})

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -116,11 +116,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             try:
                 if (deviceId := dev["deviceKey"]) is None or (prodModel := dev["productModel"]) is None:
                     continue
-                _LOGGER.info(f"Adding device: {deviceId} {prodModel} => {dev}")
+                _LOGGER.info("Adding device: %s %s => %s", deviceId, prodModel, dev)
 
                 init = Api.createdevice.get(prodModel.lower().strip(), None)
                 if init is None:
-                    _LOGGER.info(f"Device {prodModel} is not supported!")
+                    _LOGGER.info("Device %s is not supported!", prodModel)
                     continue
 
                 # create the device and mqtt server
@@ -145,19 +145,19 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                         else:
                             await provider.async_change_password(deviceId.lower(), psw)
 
-                        _LOGGER.info(f"Managed MQTT user for device: {deviceId}")
+                        _LOGGER.info("Managed MQTT user for device: %s", deviceId)
 
                     except Exception as err:
-                        _LOGGER.error(f"Failed to manage MQTT user for {deviceId}: {err}")
+                        _LOGGER.error("Failed to manage MQTT user for %s: %s", deviceId, err)
                 elif auto_mqtt:
-                    _LOGGER.debug(f"Skipping auto MQTT user creation for {deviceId}: Local server not configured.")
+                    _LOGGER.debug("Skipping auto MQTT user creation for %s: Local server not configured.", deviceId)
 
             except Exception as e:
-                _LOGGER.error(f"Unable to create device {e}!")
+                _LOGGER.error("Unable to create device %s!", e)
                 _LOGGER.error(traceback.format_exc())
 
         self.devices = list(Api.devices.values())
-        _LOGGER.info(f"Loaded {len(self.devices)} devices")
+        _LOGGER.info("Loaded %s devices", len(self.devices))
 
         # initialize the api & p1 meter
         self.api.Init(self.config_entry.data, mqtt)
@@ -251,7 +251,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
     async def update_operation(self, entity: ZendureSelect, _operation: Any) -> None:
         operation = ManagerMode(entity.value)
-        _LOGGER.info(f"Update operation: {operation} from: {self.operation}")
+        _LOGGER.info("Update operation: %s from: %s", operation, self.operation)
 
         self.operation = operation
         if self.p1meterEvent is not None:
@@ -275,7 +275,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                         continue
                     sn = d.decode("utf8")[:-1]
                     if device.snNumber.endswith(sn):
-                        _LOGGER.info(f"Found Zendure Bluetooth device: {si}")
+                        _LOGGER.info("Found Zendure Bluetooth device: %s", si)
                         device.attr_device_info["connections"] = {("bluetooth", str(si.address))}
                         return True
                 except Exception:  # noqa: S112
@@ -291,7 +291,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     if isBleDevice(device, si):
                         break
 
-            _LOGGER.debug(f"Update device: {device.name} ({device.deviceId})")
+            _LOGGER.debug("Update device: %s (%s)", device.name, device.deviceId)
             await device.dataRefresh(self.update_count)
             if device.hemsState.is_on and (time - device.hemsStateUpdated).total_seconds() > SmartMode.HEMSOFF_TIMEOUT:
                 device.hemsState.update_value(0)
@@ -467,7 +467,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             setpoint = max(0 if p1 >= 0 else setpoint - self.discharge_bypass, setpoint - self.discharge_bypass)
 
         # Update power distribution.
-        _LOGGER.info(f"P1 ======> p1:{p1} isFast:{isFast}, setpoint:{setpoint}W stored:{self.produced}W")
+        _LOGGER.info("P1 ======> p1:%s isFast:%s, setpoint:%sW stored:%sW", p1, isFast, setpoint, self.produced)
         match self.operation:
             case ManagerMode.MATCHING:
                 if setpoint < 0:
@@ -502,7 +502,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
     async def power_charge(self, setpoint: int, time: datetime) -> None:
         """Charge devices."""
-        _LOGGER.info(f"Charge => setpoint {setpoint}W")
+        _LOGGER.info("Charge => setpoint %sW", setpoint)
 
         # stop discharging devices
         for d in self.discharge:
@@ -564,7 +564,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
     async def power_discharge(self, setpoint: int) -> None:
         """Discharge devices."""
-        _LOGGER.info(f"Discharge => setpoint {setpoint}W")
+        _LOGGER.info("Discharge => setpoint %sW", setpoint)
         self.operationstate.update_value(ManagerState.DISCHARGE.value if setpoint > 0 and self.discharge else ManagerState.IDLE.value)
 
         # reset hysteria time

--- a/custom_components/zendure_ha/number.py
+++ b/custom_components/zendure_ha/number.py
@@ -68,7 +68,7 @@ class ZendureNumber(EntityZendure, NumberEntity):
             if self.hass and self.hass.loop.is_running():
                 self.schedule_update_ha_state()
         except Exception as err:
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
 
         return True
 

--- a/custom_components/zendure_ha/select.py
+++ b/custom_components/zendure_ha/select.py
@@ -70,7 +70,7 @@ class ZendureSelect(EntityZendure, SelectEntity):
                         self.schedule_update_ha_state()
 
         except Exception as err:
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
         return True
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/zendure_ha/sensor.py
+++ b/custom_components/zendure_ha/sensor.py
@@ -69,7 +69,7 @@ class ZendureSensor(EntityZendure, SensorEntity):
 
         except Exception as err:
             self._attr_native_value = value
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
             _LOGGER.error(traceback.format_exc())
         return False
 
@@ -115,7 +115,7 @@ class ZendureRestoreSensor(ZendureSensor, RestoreEntity):
         state = await self.async_get_last_state()
         try:
             self._attr_native_value = init_value if state is None else parse_datetime(state.state) if self.device_class in ["date", "timestamp"] else float(state.state)
-            _LOGGER.debug(f"Restored state for {self.entity_id}: {self._attr_native_value}")
+            _LOGGER.debug("Restored state for %s: %s", self.entity_id, self._attr_native_value)
         except ValueError:
             self._attr_native_value = init_value
 
@@ -133,7 +133,7 @@ class ZendureRestoreSensor(ZendureSensor, RestoreEntity):
                 if not isinstance(self.state, (int, float)):
                     self._attr_native_value = 0.0
 
-                _LOGGER.error(f"Unable to update aggregation {e}!")
+                _LOGGER.error("Unable to update aggregation %s!", e)
 
         self.last_value = value
         self.lastValueUpdate = time
@@ -170,7 +170,7 @@ class ZendureCalcSensor(ZendureSensor):
 
         except Exception as err:
             self._attr_native_value = value
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
             _LOGGER.error(traceback.format_exc())
         return False
 

--- a/custom_components/zendure_ha/switch.py
+++ b/custom_components/zendure_ha/switch.py
@@ -53,13 +53,13 @@ class ZendureSwitch(EntityZendure, SwitchEntity):
             if self._attr_is_on == is_on:
                 return False
 
-            _LOGGER.info(f"Update switch: {self._attr_unique_id} => {is_on}")
+            _LOGGER.info("Update switch: %s => %s", self._attr_unique_id, is_on)
 
             self._attr_is_on = is_on
             if self.hass and self.hass.loop.is_running():
                 self.schedule_update_ha_state()
         except Exception as err:
-            _LOGGER.error(f"Error {err} setting state: {self._attr_unique_id} => {value}")
+            _LOGGER.error("Error %s setting state: %s => %s", err, self._attr_unique_id, value)
         return True
 
     async def async_turn_on(self, **_kwargs: Any) -> None:


### PR DESCRIPTION
## Summary

Replaces all f-string `_LOGGER` calls with lazy `%s`-formatting across the integration.

**Why:**
- **Performance:** Lazy formatting only evaluates the message string when the log level is active. In high-frequency loops (e.g. the P1 Smart Mode update cycle running multiple times per second), this avoids thousands of unnecessary string interpolations for DEBUG messages while running at INFO level.
- **Linting compliance:** Matches ruff rule `G004` (`logging-f-string`) and pylint `W1203`, aligning with Home Assistant Core's logging conventions.
- **No behavior change:** Identical log output, only evaluation timing differs.

## Scope

71 occurrences converted across 17 files:

```
api.py              7
binary_sensor.py    1
config_flow.py      1
device.py          24 (incl. one commented-out line)
entity.py           3
manager.py         13
number.py           1
select.py           1
sensor.py           4
switch.py           2
devices/ace1500.py        2
devices/aio2400.py        2
devices/hub1200.py        2
devices/hub2000.py        2
devices/hyper2000.py      2
devices/superbasev4600.py 2
devices/superbasev6400.py 2
```

## Test plan

- [ ] Integration loads without errors
- [ ] Log output identical to previous behavior at INFO / DEBUG level
- [ ] No new ruff / pylint warnings introduced