### PR TITLE
zero-export Power Distribution example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This Home Assistant integration connects your Zendure devices to Home Assistant,
 
 - **Device Automation:**
   - Cheap hours.
+  - [Example: Zero-Export Power Distribution](#example-zero-export-power-distribution)
 
 ## Minimum Requirements
 - [Home Assistant](https://github.com/home-assistant/core) 2025.5+
@@ -63,6 +64,93 @@ To install via HACS:
 
    [![Set up a new integration in Home Assistant](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=zendure_ha)
 
+
+## Example: Zero-Export Power Distribution
+
+This automation adjusts a SolarFlow 800 Pro's output limit every 5 seconds to match household consumption (read from an external smart meter), while protecting LiFePO4 battery lifetime with a configurable low-SoC taper.
+
+**How it works**
+- Triggers on a 5-second rolling average of grid power (positive = importing from grid)
+- Incrementally adjusts `output_limit`: `new = current_limit + grid − 10W` (safety buffer against feed-in)
+- Below `soc_minimum`: output forced to 0
+- Between `soc_minimum` and `soc_minimum + 10%`: linear taper from 0 to full
+- Above: full match to consumption
+- Clamped to `[0, maximum_inverter_power]`
+- Skips the API call if change is < 10 W (dead band)
+
+**Guard conditions** — the automation only runs when:
+- Both sensors are available
+- Operation mode is `manual` (otherwise the integration's own smart logic would fight the automation)
+- Bypass is off (during bypass, `output_limit` has no effect)
+- HEMS is inactive
+
+**Required sensors/entities**
+- `sensor.iot05_current_power_5s_avg` — your smart-meter reading, 5 s average (replace with your own grid-power sensor)
+- `sensor.solarflow_800_pro_battery_soc` — battery state of charge (`electricLevel`)
+- `number.solarflow_800_pro_soc_minimum` / `_soc_maximum` — SoC bounds (`minSoc` / `socSet`)
+- `number.solarflow_800_pro_output_limit` — the inverter output limit (`outputLimit`)
+- `sensor.solarflow_800_pro_maximum_inverter_power` — max inverter output (`inverseMaxPower`)
+- `select.solarflow_800_pro_operation_mode` — Zendure operation mode
+- `binary_sensor.solarflow_800_pro_bypass` / `_hems_active` — bypass & HEMS state
+
+Rename entity IDs to match your device. Paste the YAML below into the automation's **Edit in YAML** view (replace the whole body).
+
+```yaml
+alias: Power Distribution
+mode: single
+trigger:
+  - platform: state
+    entity_id: sensor.iot05_current_power_5s_avg
+condition:
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: sensor.iot05_current_power_5s_avg
+        state:
+          - unavailable
+          - unknown
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: sensor.solarflow_800_pro_battery_soc
+        state:
+          - unavailable
+          - unknown
+  - condition: state
+    entity_id: select.solarflow_800_pro_operation_mode
+    state: manual
+  - condition: state
+    entity_id: binary_sensor.solarflow_800_pro_bypass
+    state: "off"
+  - condition: state
+    entity_id: binary_sensor.solarflow_800_pro_hems_active
+    state: "off"
+action:
+  - variables:
+      taper_width: 10
+      grid: "{{ states('sensor.iot05_current_power_5s_avg') | float(0) }}"
+      soc: "{{ states('sensor.solarflow_800_pro_battery_soc') | float(0) }}"
+      soc_min: "{{ states('number.solarflow_800_pro_soc_minimum') | float(10) }}"
+      current_limit: "{{ states('number.solarflow_800_pro_output_limit') | float(0) }}"
+      max_power: "{{ states('sensor.solarflow_800_pro_maximum_inverter_power') | float(800) }}"
+      raw_target: "{{ current_limit + grid - 10 }}"
+      target: |
+        {% if soc <= soc_min %}
+          0
+        {% elif soc <= soc_min + taper_width %}
+          {{ raw_target * ((soc - soc_min) / taper_width) }}
+        {% else %}
+          {{ raw_target }}
+        {% endif %}
+      clamped: "{{ [[target | float, 0] | max, max_power] | min | round(0) }}"
+  - condition: template
+    value_template: "{{ (soc <= soc_min and current_limit > 0) or (clamped | float - current_limit) | abs > 10 }}"
+  - service: number.set_value
+    target:
+      entity_id: number.solarflow_800_pro_output_limit
+    data:
+      value: "{{ clamped }}"
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -71,51 +71,62 @@ This automation adjusts a SolarFlow 800 Pro's output limit every 5 seconds to ma
 
 **How it works**
 - Triggers on a 5-second rolling average of grid power (positive = importing from grid)
-- Incrementally adjusts `output_limit`: `new = current_limit + grid − feed_buffer` (buffer against feed-in; default 40 W)
+- Incrementally adjusts `output_limit`: `new = current_limit + grid − feed_buffer`
 - Below `soc_minimum`: output forced to 0
 - Between `soc_minimum` and `soc_minimum + 10%`: linear taper from 0 to full
 - Above: full match to consumption
 - Clamped to `[0, maximum_inverter_power]`
-- Skips the API call if change is < 10 W (dead band)
 
-**Required sensors/entities**
-- `sensor.iot05_current_power_5s_avg` — your smart-meter reading, 5 s average (replace with your own grid-power sensor)
-- `sensor.solarflow_800_pro_battery_soc` — battery state of charge (`electricLevel`)
-- `number.solarflow_800_pro_soc_minimum` — SoC lower bound (`minSoc`)
-- `number.solarflow_800_pro_output_limit` — the inverter output limit (`outputLimit`)
-- `sensor.solarflow_800_pro_maximum_inverter_power` — max inverter output (`inverseMaxPower`)
+**Tunable knobs**
+- `feed_buffer` (default 40 W) — how much the automation deliberately *undershoots* household demand. A higher value means more sustained grid import but a safer margin against export spikes between updates. Lower if your meter and load are stable, raise if you still see feed-in.
+- `dead_band` (default 10 W) — the minimum change in `output_limit` needed to trigger an API call. Skipping small adjustments reduces chatter to the Zendure cloud/device. If the SoC is at or below `soc_minimum`, the dead band is bypassed (emergency shutdown always fires).
 
-Rename entity IDs to match your device. Make sure the integration's **Operation Mode** is set to `Manual Power` — otherwise the integration's own smart logic will fight the automation. Paste the YAML below into the automation's **Edit in YAML** view (replace the whole body).
+**Required sensors/entities** (replace the `<...>` placeholders with your actual entity IDs)
+- `sensor.<GRID_POWER_SENSOR>` — your smart-meter reading of grid power, ideally a short rolling average (positive = import, negative = export)
+- `sensor.<ZENDURE_DEVICE>_battery_soc` — battery state of charge (`electricLevel`)
+- `number.<ZENDURE_DEVICE>_soc_minimum` — SoC lower bound (`minSoc`)
+- `number.<ZENDURE_DEVICE>_output_limit` — the inverter output limit (`outputLimit`)
+- `sensor.<ZENDURE_DEVICE>_maximum_inverter_power` — max inverter output (`inverseMaxPower`)
+
+Before enabling the automation, make sure the integration's **Operation Mode** is set to `Manual Power` — otherwise the integration's own smart logic will fight the automation. Paste the YAML below into the automation's **Edit in YAML** view (replace the whole body), then search-and-replace the two placeholders.
 
 ```yaml
 alias: Power Distribution
 mode: single
-trigger:
-  - platform: state
-    entity_id: sensor.iot05_current_power_5s_avg
-condition:
+triggers:
+  - trigger: state
+    entity_id: sensor.<GRID_POWER_SENSOR>
+conditions:
   - condition: not
     conditions:
       - condition: state
-        entity_id: sensor.iot05_current_power_5s_avg
+        entity_id: sensor.<GRID_POWER_SENSOR>
         state:
           - unavailable
           - unknown
   - condition: not
     conditions:
       - condition: state
-        entity_id: sensor.solarflow_800_pro_battery_soc
+        entity_id: sensor.<ZENDURE_DEVICE>_battery_soc
         state:
           - unavailable
           - unknown
-action:
+  - condition: not
+    conditions:
+      - condition: state
+        entity_id: number.<ZENDURE_DEVICE>_output_limit
+        state:
+          - unavailable
+          - unknown
+actions:
   - variables:
       feed_buffer: 40
-      grid: "{{ states('sensor.iot05_current_power_5s_avg') | float(0) }}"
-      soc: "{{ states('sensor.solarflow_800_pro_battery_soc') | float(0) }}"
-      soc_min: "{{ states('number.solarflow_800_pro_soc_minimum') | float(10) }}"
-      current_limit: "{{ states('number.solarflow_800_pro_output_limit') | float(0) }}"
-      max_power: "{{ states('sensor.solarflow_800_pro_maximum_inverter_power') | float(800) }}"
+      dead_band: 10
+      grid: "{{ states('sensor.<GRID_POWER_SENSOR>') | float(0) }}"
+      soc: "{{ states('sensor.<ZENDURE_DEVICE>_battery_soc') | float(0) }}"
+      soc_min: "{{ states('number.<ZENDURE_DEVICE>_soc_minimum') | float(10) }}"
+      current_limit: "{{ states('number.<ZENDURE_DEVICE>_output_limit') | float(0) }}"
+      max_power: "{{ states('sensor.<ZENDURE_DEVICE>_maximum_inverter_power') | float(800) }}"
       raw_target: "{{ current_limit + grid - feed_buffer }}"
       taper_zone: "{{ soc_min + 10 }}"
       target: >-
@@ -125,10 +136,10 @@ action:
         {% endif %}
       clamped: "{{ [[target | float, 0] | max, max_power] | min | round(0) }}"
   - condition: template
-    value_template: "{{ clamped | float != current_limit and (soc <= soc_min or (clamped | float - current_limit) | abs > 10) }}"
-  - service: number.set_value
+    value_template: "{{ clamped | float != current_limit and (soc <= soc_min or (clamped | float - current_limit) | abs > dead_band) }}"
+  - action: number.set_value
     target:
-      entity_id: number.solarflow_800_pro_output_limit
+      entity_id: number.<ZENDURE_DEVICE>_output_limit
     data:
       value: "{{ clamped }}"
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This automation adjusts a SolarFlow 800 Pro's output limit every 5 seconds to ma
 
 **How it works**
 - Triggers on a 5-second rolling average of grid power (positive = importing from grid)
-- Incrementally adjusts `output_limit`: `new = current_limit + grid − 10W` (safety buffer against feed-in)
+- Incrementally adjusts `output_limit`: `new = current_limit + grid − feed_buffer` (buffer against feed-in; default 40 W)
 - Below `soc_minimum`: output forced to 0
 - Between `soc_minimum` and `soc_minimum + 10%`: linear taper from 0 to full
 - Above: full match to consumption
@@ -110,12 +110,13 @@ condition:
           - unknown
 action:
   - variables:
+      feed_buffer: 40
       grid: "{{ states('sensor.iot05_current_power_5s_avg') | float(0) }}"
       soc: "{{ states('sensor.solarflow_800_pro_battery_soc') | float(0) }}"
       soc_min: "{{ states('number.solarflow_800_pro_soc_minimum') | float(10) }}"
       current_limit: "{{ states('number.solarflow_800_pro_output_limit') | float(0) }}"
       max_power: "{{ states('sensor.solarflow_800_pro_maximum_inverter_power') | float(800) }}"
-      raw_target: "{{ current_limit + grid - 10 }}"
+      raw_target: "{{ current_limit + grid - feed_buffer }}"
       taper_zone: "{{ soc_min + 10 }}"
       target: >-
         {% if soc <= soc_min %} 0

--- a/README.md
+++ b/README.md
@@ -78,22 +78,14 @@ This automation adjusts a SolarFlow 800 Pro's output limit every 5 seconds to ma
 - Clamped to `[0, maximum_inverter_power]`
 - Skips the API call if change is < 10 W (dead band)
 
-**Guard conditions** — the automation only runs when:
-- Both sensors are available
-- Operation mode is `manual` (otherwise the integration's own smart logic would fight the automation)
-- Bypass is off (during bypass, `output_limit` has no effect)
-- HEMS is inactive
-
 **Required sensors/entities**
 - `sensor.iot05_current_power_5s_avg` — your smart-meter reading, 5 s average (replace with your own grid-power sensor)
 - `sensor.solarflow_800_pro_battery_soc` — battery state of charge (`electricLevel`)
-- `number.solarflow_800_pro_soc_minimum` / `_soc_maximum` — SoC bounds (`minSoc` / `socSet`)
+- `number.solarflow_800_pro_soc_minimum` — SoC lower bound (`minSoc`)
 - `number.solarflow_800_pro_output_limit` — the inverter output limit (`outputLimit`)
 - `sensor.solarflow_800_pro_maximum_inverter_power` — max inverter output (`inverseMaxPower`)
-- `select.solarflow_800_pro_operation_mode` — Zendure operation mode
-- `binary_sensor.solarflow_800_pro_bypass` / `_hems_active` — bypass & HEMS state
 
-Rename entity IDs to match your device. Paste the YAML below into the automation's **Edit in YAML** view (replace the whole body).
+Rename entity IDs to match your device. Make sure the integration's **Operation Mode** is set to `Manual Power` — otherwise the integration's own smart logic will fight the automation. Paste the YAML below into the automation's **Edit in YAML** view (replace the whole body).
 
 ```yaml
 alias: Power Distribution
@@ -116,35 +108,23 @@ condition:
         state:
           - unavailable
           - unknown
-  - condition: state
-    entity_id: select.solarflow_800_pro_operation_mode
-    state: manual
-  - condition: state
-    entity_id: binary_sensor.solarflow_800_pro_bypass
-    state: "off"
-  - condition: state
-    entity_id: binary_sensor.solarflow_800_pro_hems_active
-    state: "off"
 action:
   - variables:
-      taper_width: 10
       grid: "{{ states('sensor.iot05_current_power_5s_avg') | float(0) }}"
       soc: "{{ states('sensor.solarflow_800_pro_battery_soc') | float(0) }}"
       soc_min: "{{ states('number.solarflow_800_pro_soc_minimum') | float(10) }}"
       current_limit: "{{ states('number.solarflow_800_pro_output_limit') | float(0) }}"
       max_power: "{{ states('sensor.solarflow_800_pro_maximum_inverter_power') | float(800) }}"
       raw_target: "{{ current_limit + grid - 10 }}"
-      target: |
-        {% if soc <= soc_min %}
-          0
-        {% elif soc <= soc_min + taper_width %}
-          {{ raw_target * ((soc - soc_min) / taper_width) }}
-        {% else %}
-          {{ raw_target }}
+      taper_zone: "{{ soc_min + 10 }}"
+      target: >-
+        {% if soc <= soc_min %} 0
+        {% elif soc <= taper_zone %} {{ (raw_target | float) * ((soc - soc_min) / 10) }}
+        {% else %} {{ raw_target }}
         {% endif %}
       clamped: "{{ [[target | float, 0] | max, max_power] | min | round(0) }}"
   - condition: template
-    value_template: "{{ (soc <= soc_min and current_limit > 0) or (clamped | float - current_limit) | abs > 10 }}"
+    value_template: "{{ clamped | float != current_limit and (soc <= soc_min or (clamped | float - current_limit) | abs > 10) }}"
   - service: number.set_value
     target:
       entity_id: number.solarflow_800_pro_output_limit


### PR DESCRIPTION
If you're controlling the power management through HA, this PR documents a working automation for anyone else trying to keep their SolarFlow 800 Pro from cheerfully feeding power back to the grid.
  - Tunable `feed_buffer` (default 40 W) and `dead_band` (default 10 W), with actual explanations of what those words mean                                                                                                                                                  
  - Availability guards on grid sensor, battery SoC, and `output_limit` — so it doesn't compute a new setpoint from a phantom zero if the device is sulking
  - LiFePO4-friendly SoC taper between `soc_min` and `soc_min + 10%`
  - Placeholders (`<GRID_POWER_SENSOR>`, `<ZENDURE_DEVICE>`) so the snippet is copy-pasteable without everyone learning what I named my device

Pure docs. No code touched. No entities harmed in the making of this PR.