### PR TITLE
Refine renaming migration (supersedes #1272)

### DIFF
--- a/custom_components/zendure_ha/__init__.py
+++ b/custom_components/zendure_ha/__init__.py
@@ -19,23 +19,22 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> bool:
     """Migrate config entry to new version."""
-    _LOGGER.info("Migrating Zendure config entry from version %s.%s", entry.version, entry.minor_version)
     if entry.version == 1 and entry.minor_version < 5:
-        await Migration.async_migrate(hass, entry.entry_id)
+        _LOGGER.info("Migrating Zendure config entry from version %s.%s", entry.version, entry.minor_version)
+        await Migration.async_migrate(hass, entry.entry_id, entry.domain)
     hass.config_entries.async_update_entry(entry, version=1, minor_version=5)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> bool:
     """Set up Zendure as config entry."""
-    manager = ZendureManager(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    manager = ZendureManager(hass, entry)
     await manager.loadDevices()
     entry.runtime_data = manager
     await manager.async_config_entry_first_refresh()
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
-
 
 async def update_listener(_hass: HomeAssistant, entry: ZendureConfigEntry) -> None:
     """Handle options update."""

--- a/custom_components/zendure_ha/__init__.py
+++ b/custom_components/zendure_ha/__init__.py
@@ -21,7 +21,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ZendureConfigEntry) ->
     """Migrate config entry to new version."""
     if entry.version == 1 and entry.minor_version < 5:
         _LOGGER.info("Migrating Zendure config entry from version %s.%s", entry.version, entry.minor_version)
-        await Migration.async_migrate(hass, entry.entry_id, entry.domain)
+        await Migration.async_migrate(hass, entry.entry_id)
     hass.config_entries.async_update_entry(entry, version=1, minor_version=5)
     return True
 
@@ -35,6 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> b
     await manager.async_config_entry_first_refresh()
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
+
 
 async def update_listener(_hass: HomeAssistant, entry: ZendureConfigEntry) -> None:
     """Handle options update."""

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -44,41 +44,45 @@ SF_COMMAND_CHAR = "0000c304-0000-1000-8000-00805f9b34fb"
 class ZendureBattery(EntityDevice):
     """Zendure Battery class for devices."""
 
-    def __init__(self, hass: HomeAssistant, sn: str, parent: EntityDevice) -> None:
-        """Initialize Device."""
-        self.kWh = 0.0
+    def get_battery_type(sn: str) -> tuple[str, str, float]:
         model = "???"
         match sn[0]:
             case "A":
                 if sn[3] == "3":
                     model = "AIO2400"
-                    self.kWh = 2.4
+                    kWh = 2.4
                 else:
                     model = "AB1000"
-                    self.kWh = 0.96
+                    kWh = 0.96
             case "B":
                 model = "AB1000S"
-                self.kWh = 0.96
+                kWh = 0.96
             case "C":
                 # External AB2000X and internal AB2000X of SF800+/SF800Pro/SF1600AC+ starting with CO4A. They are also described as additional battery in the Zendure App, even when they are integrated into the device.
                 model = "AB2000" + ("S" if sn[3] == "F" else "X" if sn[3] == "E" else "")
-                self.kWh = 1.92
+                kWh = 1.92
             case "F":
                 model = "AB3000"
-                self.kWh = 2.88
+                kWh = 2.88
             case "G":
                 model = "AB3000L"
-                self.kWh = 2.88
+                kWh = 2.88
             case "J":
                 # JO2A => internal battery of SF2400AC pro
                 # JO4A => internal battery of SF2400AC+
                 model = "I2400"
-                self.kWh = 2.4
+                kWh = 2.4
             case _:
                 model = "Unknown"
-                self.kWh = 0.0
+                kWh = 0.0
 
         name = f"{model} {sn[-5:]}".strip()
+        return name, model, kWh
+
+    def __init__(self, hass: HomeAssistant, sn: str, parent: EntityDevice) -> None:
+        """Initialize Device."""
+        self.kWh = 0.0
+        name, model , self.kWh = ZendureBattery.get_battery_type(sn)
         super().__init__(hass, sn, name, model, "", sn, parent.sn)
         self.attr_device_info["serial_number"] = sn
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -44,6 +44,7 @@ SF_COMMAND_CHAR = "0000c304-0000-1000-8000-00805f9b34fb"
 class ZendureBattery(EntityDevice):
     """Zendure Battery class for devices."""
 
+    @staticmethod
     def get_battery_type(sn: str) -> tuple[str, str, float]:
         model = "???"
         match sn[0]:
@@ -81,8 +82,7 @@ class ZendureBattery(EntityDevice):
 
     def __init__(self, hass: HomeAssistant, sn: str, parent: EntityDevice) -> None:
         """Initialize Device."""
-        self.kWh = 0.0
-        name, model , self.kWh = ZendureBattery.get_battery_type(sn)
+        name, model, self.kWh = ZendureBattery.get_battery_type(sn)
         super().__init__(hass, sn, name, model, "", sn, parent.sn)
         self.attr_device_info["serial_number"] = sn
 

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -211,11 +211,11 @@ class EntityDevice:
             model_id=model_id,
             serial_number=sn,
         )
+        if parent is None:
+            self.attr_device_info["hw_version"] = deviceId
         device_registry = dr.async_get(self.hass)
         if di := device_registry.async_get_device(identifiers={(DOMAIN, sn)}):
             self.attr_device_info["connections"] = di.connections
-            if parent is None:
-                self.attr_device_info["hw_version"] = deviceId
 
         if parent is not None:
             self.attr_device_info["via_device"] = (DOMAIN, parent)

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -204,18 +204,18 @@ class EntityDevice:
 
         Migration.check_device(self.hass, deviceId, self.name, model, sn)
         self.attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, deviceId)},
+            identifiers={(DOMAIN, deviceId)} | {(DOMAIN, sn)},
             name=self.name,
             manufacturer="Zendure",
             model=model,
             model_id=model_id,
-            hw_version=deviceId,
             serial_number=sn,
         )
         device_registry = dr.async_get(self.hass)
         if di := device_registry.async_get_device(identifiers={(DOMAIN, sn)}):
             self.attr_device_info["connections"] = di.connections
-            self.attr_device_info["hw_version"] = deviceId
+            if parent is None:
+                self.attr_device_info["hw_version"] = deviceId
 
         if parent is not None:
             self.attr_device_info["via_device"] = (DOMAIN, parent)

--- a/custom_components/zendure_ha/migration.py
+++ b/custom_components/zendure_ha/migration.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 class Migration:
     """Handles device/entity rename migrations."""
 
-    repairs = {"i_o_t_state": "iot_state", "o_t_a_state": "ota_state", "l_c_n_state": "lcn_state", "local_a_p_i_enable": "local_api_enable", "is_error": ""}
+    repairs = {"i_o_t_state": "iotstate", "o_t_a_state": "otastate", "l_c_n_state": "lcnstate", "local_a_p_i_enable": "local_apienable", "is_error": ""}
 
     @staticmethod
     def check_device(hass: HomeAssistant, device_id: str, name: str, model: str, sn: str) -> None:
@@ -107,7 +107,8 @@ class Migration:
 
                 if device.via_device_id:
                     # is a battery device, change name to the new format
-                    name = f"{device.model} {device.serial_number[-5:]}".strip()
+                    name, model, kWh = ZendureBattery.get_battery_type(device.serial_number)
+#                    name = f"{device.model} {device.serial_number[-5:]}".strip()
                 if name != device.name:
                     _LOGGER.info("Promoting device name '%s' -> '%s'", device.name, name)
                     device_registry.async_update_device(device.id, name=name, name_by_user=None)

--- a/custom_components/zendure_ha/migration.py
+++ b/custom_components/zendure_ha/migration.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import restore_state as rs
 
 from .const import DOMAIN
 from .entity import snakecase
+from .device import ZendureBattery
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 class Migration:
     """Handles device/entity rename migrations."""
 
-    repairs = {"i_o_t_state": "iotstate", "o_t_a_state": "otastate", "l_c_n_state": "lcnstate", "local_a_p_i_enable": "local_apienable", "is_error": ""}
+    repairs = {"i_o_t_state": "iot_state", "o_t_a_state": "ota_state", "l_c_n_state": "lcn_state", "local_a_p_i_enable": "local_api_enable", "is_error": ""}
 
     @staticmethod
     def check_device(hass: HomeAssistant, device_id: str, name: str, model: str, sn: str) -> None:
@@ -80,7 +81,7 @@ class Migration:
         return file_modified
 
     @staticmethod
-    async def async_migrate(hass: HomeAssistant, entryid: str) -> None:
+    async def async_migrate(hass: HomeAssistant, entryid: str, domain: str) -> None:
         """One-time migration run via async_migrate_entry: fix device identifiers and entity IDs."""
         device_registry = dr.async_get(hass)
         entity_registry = er.async_get(hass)
@@ -89,7 +90,8 @@ class Migration:
 
         devices = dr.async_entries_for_config_entry(device_registry, entryid)
         for device in devices:
-            if not any(ident[0] == DOMAIN for ident in device.identifiers) or device.name == "Zendure Manager":
+#            if not any(ident[0] == DOMAIN for ident in device.identifiers) or device.name == "Zendure Manager":
+            if not any(ident[0] == DOMAIN for ident in device.identifiers):
                 continue
 
             try:
@@ -103,44 +105,86 @@ class Migration:
                 if not (name := device.name_by_user or device.name) or "_" in name:
                     continue
 
+                if device.via_device_id:
+                    # is a battery device, change name to the new format
+                    name = f"{device.model} {device.serial_number[-5:]}".strip()
                 if name != device.name:
                     _LOGGER.info("Promoting device name '%s' -> '%s'", device.name, name)
                     device_registry.async_update_device(device.id, name=name, name_by_user=None)
 
                 for entity in entities:
                     try:
-                        if entity.translation_key is None:
-                            entity_registry.async_remove(entity.entity_id)
-                            _LOGGER.debug("Removed orphan entity %s", entity.entity_id)
-                            continue
+                        # rename only entities which belong to the zendure_ha domain
+                        if entity.platform == domain:
+                            if entity.translation_key is None:
+                                entity_registry.async_remove(entity.entity_id)
+                                _LOGGER.debug("Removed orphan entity %s", entity.entity_id)
+                                continue
 
-                        uniqueid = snakecase(v) if (v := Migration.repairs.get(entity.translation_key)) is not None else snakecase(entity.translation_key)
-                        if uniqueid == "":
-                            entity_registry.async_remove(entity.entity_id)
-                            continue
+                            uniqueid = snakecase(v) if (v := Migration.repairs.get(entity.translation_key)) is not None else snakecase(entity.translation_key)
+                            if uniqueid == "":
+                                entity_registry.async_remove(entity.entity_id)
+                                continue
 
-                        if uniqueid.startswith("aggr") and uniqueid.endswith("total"):
-                            uniqueid = uniqueid.replace("_total", "")
-                        unique_id = snakecase(f"{name.lower()}_{uniqueid}")
-                        entityid = f"{entity.domain}.{unique_id}"
+                            if uniqueid.startswith("aggr") and uniqueid.endswith("total"):
+                                uniqueid = uniqueid.replace("_total", "")
+                            unique_id = snakecase(f"{name.lower()}_{uniqueid}")
+                            entityid = f"{entity.domain}.{unique_id}"
 
-                        if entity.entity_id != entityid or entity.unique_id != unique_id or entity.translation_key != uniqueid:
-                            if entity.entity_id != entityid:
-                                entity_registry.async_remove(entityid)
-                            if (rstate := data.last_states.pop(entity.entity_id, None)) is not None:
-                                data.last_states[entityid] = rstate
-                            entity_registry.async_update_entity(
-                                entity.entity_id,
-                                new_unique_id=unique_id,
-                                new_entity_id=entityid,
-                                translation_key=uniqueid,
-                            )
-                            _LOGGER.debug("Migrated entity %s -> %s", entity.entity_id, entityid)
-                            changes.append((entity.entity_id, entityid))
+                            if entity.entity_id != entityid or entity.unique_id != unique_id or entity.translation_key != uniqueid:
+                                if entity.entity_id != entityid:
+                                    entity_registry.async_remove(entityid)
+                                if (rstate := data.last_states.pop(entity.entity_id, None)) is not None:
+                                    data.last_states[entityid] = rstate
+                                entity_registry.async_update_entity(
+                                    entity.entity_id,
+                                    new_unique_id=unique_id,
+                                    new_entity_id=entityid,
+                                    translation_key=uniqueid,
+                                )
+                                _LOGGER.debug("Migrated entity %s -> %s", entity.entity_id, entityid)
+                                changes.append((entity.entity_id, entityid))
                     except Exception as e:
                         _LOGGER.error("Failed to migrate entity %s: %s", entity.entity_id, e)
             except Exception as e:
                 _LOGGER.error("Failed to migrate entity %s: %s", entity.entity_id, e)
+
+        # update template config entries
+        modified = 0
+        for entry in hass.config_entries.async_entries():
+            new_data = dict(entry.data or {})
+            new_options = dict(entry.options or {})
+            if len(new_data) == 0 and len(new_options) == 0:
+                continue
+
+            def change_id(data: dict, oid: str, nid: str) -> bool:
+                changed = False
+                for key, value in data.items():
+                    if isinstance(value, dict):
+                        change_id(value, oid, nid)
+                        changed = True
+                    elif isinstance(value, list):
+                        for i, item in enumerate(value):
+                            if isinstance(item, str) and oid in item:
+                                value[i] = item.replace(oid, nid)
+                                changed = True
+                    elif isinstance(value, str) and oid in value:
+                        data[key] = data[key] = value.replace(oid, nid)
+                        changed = True
+                return changed
+
+            changed = False
+            for oid, nid in changes:
+                changed |= change_id(new_data, oid, nid)
+                changed |= change_id(new_options, oid, nid)
+
+            if changed:
+                hass.config_entries.async_update_entry(
+                    entry, data=new_data, options=new_options
+                )
+                hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+                modified += 1
+        _LOGGER.info("Modified %i template entities", modified)
 
         if changes and await hass.async_add_executor_job(Migration._update_files, hass, changes):
             await rs.RestoreStateData.async_save_persistent_states(hass)

--- a/custom_components/zendure_ha/migration.py
+++ b/custom_components/zendure_ha/migration.py
@@ -10,8 +10,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import restore_state as rs
 
 from .const import DOMAIN
-from .entity import snakecase
 from .device import ZendureBattery
+from .entity import snakecase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class Migration:
         return file_modified
 
     @staticmethod
-    async def async_migrate(hass: HomeAssistant, entryid: str, domain: str) -> None:
+    async def async_migrate(hass: HomeAssistant, entryid: str) -> None:
         """One-time migration run via async_migrate_entry: fix device identifiers and entity IDs."""
         device_registry = dr.async_get(hass)
         entity_registry = er.async_get(hass)
@@ -90,7 +90,6 @@ class Migration:
 
         devices = dr.async_entries_for_config_entry(device_registry, entryid)
         for device in devices:
-#            if not any(ident[0] == DOMAIN for ident in device.identifiers) or device.name == "Zendure Manager":
             if not any(ident[0] == DOMAIN for ident in device.identifiers):
                 continue
 
@@ -107,8 +106,7 @@ class Migration:
 
                 if device.via_device_id:
                     # is a battery device, change name to the new format
-                    name, model, kWh = ZendureBattery.get_battery_type(device.serial_number)
-#                    name = f"{device.model} {device.serial_number[-5:]}".strip()
+                    name, _, _ = ZendureBattery.get_battery_type(device.serial_number)
                 if name != device.name:
                     _LOGGER.info("Promoting device name '%s' -> '%s'", device.name, name)
                     device_registry.async_update_device(device.id, name=name, name_by_user=None)
@@ -116,7 +114,7 @@ class Migration:
                 for entity in entities:
                     try:
                         # rename only entities which belong to the zendure_ha domain
-                        if entity.platform == domain:
+                        if entity.platform == DOMAIN:
                             if entity.translation_key is None:
                                 entity_registry.async_remove(entity.entity_id)
                                 _LOGGER.debug("Removed orphan entity %s", entity.entity_id)
@@ -162,15 +160,14 @@ class Migration:
                 changed = False
                 for key, value in data.items():
                     if isinstance(value, dict):
-                        change_id(value, oid, nid)
-                        changed = True
+                        changed |= change_id(value, oid, nid)
                     elif isinstance(value, list):
                         for i, item in enumerate(value):
                             if isinstance(item, str) and oid in item:
                                 value[i] = item.replace(oid, nid)
                                 changed = True
                     elif isinstance(value, str) and oid in value:
-                        data[key] = data[key] = value.replace(oid, nid)
+                        data[key] = value.replace(oid, nid)
                         changed = True
                 return changed
 
@@ -180,12 +177,10 @@ class Migration:
                 changed |= change_id(new_options, oid, nid)
 
             if changed:
-                hass.config_entries.async_update_entry(
-                    entry, data=new_data, options=new_options
-                )
+                hass.config_entries.async_update_entry(entry, data=new_data, options=new_options)
                 hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
                 modified += 1
-        _LOGGER.info("Modified %i template entities", modified)
+        _LOGGER.info("Modified %d template entities", modified)
 
         if changes and await hass.async_add_executor_job(Migration._update_files, hass, changes):
             await rs.RestoreStateData.async_save_persistent_states(hass)


### PR DESCRIPTION
Includes the five commits from #1272 by @harrymayr (battery-type extraction, migration logging, device-info identifier/hw_version handling, entity-platform scoping, template config-entry rewrite) plus one cleanup commit on top.

Cleanup commit addresses:
- `@staticmethod` on `ZendureBattery.get_battery_type`, drop dead `self.kWh = 0.0` init
- `change_id` now propagates recursive result via `changed |=` so unrelated config entries aren't reloaded unnecessarily
- Drop double-assign `data[key] = data[key] = …`, `%i` → `%d` in migration log
- Restore `hw_version` up-front for top-level devices (fresh installs); still skipped for batteries
- Remove commented-out code, reference `DOMAIN` directly instead of threading `entry.domain` through `async_migrate`

Supersedes #1272.