### PR TITLE
Fixes for off grid devices

### DIFF
--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -64,6 +64,7 @@ class Api:
         "hyper2000_3.0": Hyper2000,
         "solarflow 800": SolarFlow800,
         "solarflow 800 pro": SolarFlow800Pro,
+        "solarflow 800 pro2": SolarFlow800Pro,
         "solarflow 800 plus": SolarFlow800Plus,
         "solarflow 1600 ac+": SolarFlow1600,
         "solarflow 2400 ac": SolarFlow2400AC,
@@ -184,6 +185,7 @@ class Api:
                 _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
                 return None
             if not data.get("success", False) or (result := data["data"]) is None:
+                _LOGGER.error("Unable to connect to Zendure API!")
                 return None
             return dict(result)
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -136,7 +136,7 @@ class ZendureDevice(EntityDevice):
         self.socSet = ZendureNumber(self, "socSet", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10)
         self.socStatus = ZendureSensor(self, "socStatus", state=0)
         self.socLimit = ZendureSensor(self, "socLimit", state=0)
-        self.byPass = ZendureBinarySensor(self, "pass")
+        self.byPass = ZendureSensor(self, "pass", state=0)
 
         fuseGroups = {0: "unused", 1: "owncircuit", 2: "group800", 3: "group800_2400", 4: "group1200", 5: "group2000", 6: "group2400", 7: "group3600"}
         self.fuseGroup = ZendureRestoreSelect(self, "fuseGroup", fuseGroups, None)
@@ -738,17 +738,17 @@ class ZendureZenSdk(ZendureDevice):
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
         _LOGGER.info("Power charge %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
+        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 
     async def discharge(self, power: int) -> int:
         _LOGGER.info("Power discharge %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
+        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
         return power
 
     async def power_off(self) -> None:
         """Set the power off."""
-        await self.doCommand({"properties": {"smartMode": 0, "acMode": 2, "outputLimit": 0, "inputLimit": 0}})
+        await self.doCommand({"properties": {"smartMode": 0 if self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": 0, "inputLimit": 0}})
 
     async def doCommand(self, command: Any) -> None:
         if self.connection.value != 0:

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -150,7 +150,6 @@ class EntityDevice:
         "heatState": ("binary"),
         "restState": ("binary"),
         "reverseState": ("binary"),
-        "pass": ("binary"),
         "lowTemperature": ("binary"),
         "autoHeat": ("select", {0: "off", 1: "on"}, 1),
         "localState": ("binary"),

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import traceback
+import random
 from collections import deque
 from collections.abc import Callable
 from datetime import datetime, timedelta
@@ -506,6 +507,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         # stop discharging devices
         for d in self.discharge:
+            # avoid stopping bypassing devices
+            if d.byPass.asInt > 0:
+                continue
             # avoid gridOff device to use power from the grid
             await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
 
@@ -557,7 +561,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # offGrid device need to be started with at least their offgrid power, otherwise they will not be recognized as charging
                 # but should not be started with more than pwr_offgrid if they are full
                 # if a offGrid device need to be started, the output power is set to 0 and it take all offGrid power from grid
-                start_pwr = max(50, min(80, abs(d.charge_limit) * 6 // 100))
+                start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, abs(d.charge_limit) * 6 // 100))
                 await d.power_charge(-start_pwr - max(0, d.pwr_offgrid) if d.state != DeviceState.SOCFULL else -max(0, d.pwr_offgrid))
                 if (dev_start := dev_start - d.charge_optimal * 2) >= 0:
                     break
@@ -621,7 +625,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             self.idle.sort(key=lambda d: d.electricLevel.asInt, reverse=True)
             for d in self.idle:
                 if d.state != DeviceState.SOCEMPTY:
-                    start_pwr = max(50, min(80, d.discharge_limit * 6 // 100))
+                    start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, d.discharge_limit * 6 // 100))
                     await d.power_discharge(start_pwr)
                     if (dev_start := dev_start - d.discharge_optimal * 2) <= 0:
                         break


### PR DESCRIPTION
- Add SF 800 pro 2 (may not show up with token auth.)
- Changing byPass to a sensor, because it covers 3 states (`Off`, `On `and `grid direct supply`)
- Avoid stopping of discharge for bypassed devices on charge -> https://github.com/Zendure/Zendure-HA/issues/1243
- Keep smartmode at 1 if offGridPower > 0
- Add random-value (0-10) to start-power, to avoid non reaction of SF 800 pro in rare cases -> https://github.com/Zendure/Zendure-HA/issues/1283