### PR TITLE
Pr 1288 review fixes

### DIFF
--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -185,7 +185,7 @@ class Api:
                 _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
                 return None
             if not data.get("success", False) or (result := data["data"]) is None:
-                _LOGGER.error("Unable to connect to Zendure API!")
+                _LOGGER.error("Zendure API returned failure or missing data: %s", data)
                 return None
             return dict(result)
 

--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -64,6 +64,7 @@ class Api:
         "hyper2000_3.0": Hyper2000,
         "solarflow 800": SolarFlow800,
         "solarflow 800 pro": SolarFlow800Pro,
+        "solarflow 800 pro2": SolarFlow800Pro,
         "solarflow 800 plus": SolarFlow800Plus,
         "solarflow 1600 ac+": SolarFlow1600,
         "solarflow 2400 ac": SolarFlow2400AC,
@@ -184,6 +185,7 @@ class Api:
                 _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
                 return None
             if not data.get("success", False) or (result := data["data"]) is None:
+                _LOGGER.error("Unable to connect to Zendure API!")
                 return None
             return dict(result)
 

--- a/custom_components/zendure_ha/binary_sensor.py
+++ b/custom_components/zendure_ha/binary_sensor.py
@@ -30,7 +30,7 @@ class ZendureBinarySensor(EntityZendure, BinarySensorEntity):
         deviceclass: Any | None = None,
     ) -> None:
         """Initialize a binary sensor entity."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "binary_sensor")
         self.entity_description = BinarySensorEntityDescription(key=uniqueid, name=uniqueid, device_class=deviceclass)
         self._attr_is_on = False
         self._value_template: Template | None = template

--- a/custom_components/zendure_ha/button.py
+++ b/custom_components/zendure_ha/button.py
@@ -23,7 +23,7 @@ class ZendureButton(EntityZendure, ButtonEntity):
 
     def __init__(self, device: EntityDevice, uniqueid: str, onpress: Callable) -> None:
         """Initialize a button."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "button")
         self.entity_description = ButtonEntityDescription(key=uniqueid, name=uniqueid)
         self._onpress = onpress
         self.add([self])

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -738,11 +738,15 @@ class ZendureZenSdk(ZendureDevice):
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
         _LOGGER.info("Power charge %s => %s", self.name, power)
+        if power == -SmartMode.POWER_START and self.limitInput.asInt == -SmartMode.POWER_START and self.homeInput.asInt == 0:
+            power -= 10
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 
     async def discharge(self, power: int) -> int:
         _LOGGER.info("Power discharge %s => %s", self.name, power)
+        if power == SmartMode.POWER_START and self.limitOutput.asInt == SmartMode.POWER_START and self.homeOutput.asInt == 0:
+            power += 10
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
         return power
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -136,7 +136,7 @@ class ZendureDevice(EntityDevice):
         self.socSet = ZendureNumber(self, "socSet", self.entityWrite, None, "%", "soc", 100, 0, NumberMode.SLIDER, 10)
         self.socStatus = ZendureSensor(self, "socStatus", state=0)
         self.socLimit = ZendureSensor(self, "socLimit", state=0)
-        self.byPass = ZendureBinarySensor(self, "pass")
+        self.byPass = ZendureSensor(self, "pass", state=0)
 
         fuseGroups = {0: "unused", 1: "owncircuit", 2: "group800", 3: "group800_2400", 4: "group1200", 5: "group2000", 6: "group2400", 7: "group3600"}
         self.fuseGroup = ZendureRestoreSelect(self, "fuseGroup", fuseGroups, None)
@@ -738,17 +738,17 @@ class ZendureZenSdk(ZendureDevice):
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
         _LOGGER.info("Power charge %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
+        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 
     async def discharge(self, power: int) -> int:
         _LOGGER.info("Power discharge %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
+        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
         return power
 
     async def power_off(self) -> None:
         """Set the power off."""
-        await self.doCommand({"properties": {"smartMode": 0, "acMode": 2, "outputLimit": 0, "inputLimit": 0}})
+        await self.doCommand({"properties": {"smartMode": 0 if self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": 0, "inputLimit": 0}})
 
     async def doCommand(self, command: Any) -> None:
         if self.connection.value != 0:

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -56,6 +56,7 @@ class EntityZendure(Entity):
         self,
         device: EntityDevice | None,
         uniqueid: str,
+        domain: str = "",
     ) -> None:
         """Initialize a Zendure entity."""
         self._attr_has_entity_name = True
@@ -70,6 +71,8 @@ class EntityZendure(Entity):
         self.internal_integration_suggested_object_id = self._attr_unique_id
         self._attr_translation_key = snakecase(uniqueid)
         device.entities[uniqueid] = self
+        if domain and (entity := f"{domain}.{{}}_{self._attr_translation_key}") not in device.checkEntity:
+            device.checkEntity.append(entity)
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -168,6 +171,9 @@ class EntityDevice:
         "ambientLightMode": ("none"),
         "ambientSwitch": ("none"),
         "PowerCycle": ("none"),
+        "faultLevel": ("none"),
+        "oldMode": ("none"),
+        "circuitCheckMode": ("none"),
         "acoutputPowerCycle": ("none"),
         "dcoutputPowerCycle": ("none"),
         "gridInputPowerCycle": ("none"),
@@ -179,6 +185,13 @@ class EntityDevice:
         "ts": ("none"),
         "tsZone": ("none"),
     }
+    checkEntity: list[str] = [
+        f"{domain}.{{}}_{snakecase(key)}"
+        for key, info in createEntity.items()
+        for domain in [{"binary": "binary_sensor", "switch": "switch", "select": "select"}.get(info if isinstance(info, str) else info[0], "sensor")]
+        if (info if isinstance(info, str) else info[0]) != "none"
+    ]
+
     empty = EntityZendure(None, "empty")
 
     def __init__(
@@ -218,6 +231,23 @@ class EntityDevice:
 
         if parent is not None:
             self.attr_device_info["via_device"] = (DOMAIN, parent)
+
+    def check_entities(self) -> None:
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+        name = snakecase(self.name.lower())
+        # translation_key → expected entity_id for all known hard-coded entities
+        known = {p.split(".", 1)[1].replace("{}_", ""): p.format(name) for p in self.checkEntity}
+        # translation_keys that must never have a registry entry
+        none_keys = {snakecase(k) for k, info in self.createEntity.items() if (info if isinstance(info, str) else info[0]) == "none"}
+        di = device_registry.async_get_device(identifiers={(DOMAIN, self.sn)}) or device_registry.async_get_device(identifiers={(DOMAIN, self.deviceId)})
+        if di:
+            for entry in er.async_entries_for_device(entity_registry, di.id, True):
+                if entry.platform != DOMAIN or entry.translation_key is None:
+                    continue
+                if entry.translation_key in none_keys or (entry.translation_key in known and entry.entity_id != known[entry.translation_key]):
+                    _LOGGER.info("Removing stale entity %s", entry.entity_id)
+                    entity_registry.async_remove(entry.entity_id)
 
     async def dataRefresh(self, _update_count: int) -> None:
         return
@@ -302,7 +332,7 @@ class EntityDevice:
     def updateVersion(self, version: str) -> None:
         _LOGGER.info("Updating %s software version from %s to %s", self.name, self.attr_device_info.get("sw_version"), version)
         device_registry = dr.async_get(self.hass)
-        identifier = self.sn if self.sn else self.name
+        identifier = self.sn or self.name
         device_entry = device_registry.async_get_device(identifiers={(DOMAIN, identifier)})
         if device_entry is not None:
             device_registry.async_update_device(device_entry.id, sw_version=version)

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -150,7 +150,6 @@ class EntityDevice:
         "heatState": ("binary"),
         "restState": ("binary"),
         "reverseState": ("binary"),
-        "pass": ("binary"),
         "lowTemperature": ("binary"),
         "autoHeat": ("select", {0: "off", 1: "on"}, 1),
         "localState": ("binary"),

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import logging
 import traceback
-import random
 from collections import deque
 from collections.abc import Callable
 from datetime import datetime, timedelta
@@ -126,6 +125,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
                 # create the device and mqtt server
                 device = init(self.hass, deviceId, dev.get("deviceName", prodModel), dev)
+                device.check_entities()
                 device.discharge_start = device.discharge_limit // 10
                 device.discharge_optimal = device.discharge_limit // 4
                 Api.devices[deviceId] = device
@@ -561,7 +561,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # offGrid device need to be started with at least their offgrid power, otherwise they will not be recognized as charging
                 # but should not be started with more than pwr_offgrid if they are full
                 # if a offGrid device need to be started, the output power is set to 0 and it take all offGrid power from grid
-                start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, abs(d.charge_limit) * 6 // 100))
+                start_pwr = SmartMode.POWER_START
                 await d.power_charge(-start_pwr - max(0, d.pwr_offgrid) if d.state != DeviceState.SOCFULL else -max(0, d.pwr_offgrid))
                 if (dev_start := dev_start - d.charge_optimal * 2) >= 0:
                     break
@@ -625,8 +625,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             self.idle.sort(key=lambda d: d.electricLevel.asInt, reverse=True)
             for d in self.idle:
                 if d.state != DeviceState.SOCEMPTY:
-                    start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, d.discharge_limit * 6 // 100))
-                    await d.power_discharge(start_pwr)
+                    await d.power_discharge(SmartMode.POWER_START)
                     if (dev_start := dev_start - d.discharge_optimal * 2) <= 0:
                         break
             self.pwr_low: int = 0

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import traceback
+import random
 from collections import deque
 from collections.abc import Callable
 from datetime import datetime, timedelta
@@ -506,6 +507,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         # stop discharging devices
         for d in self.discharge:
+            # avoid stopping bypassing devices
+            if d.byPass.asInt > 0:
+                continue
             # avoid gridOff device to use power from the grid
             await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
 
@@ -557,7 +561,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # offGrid device need to be started with at least their offgrid power, otherwise they will not be recognized as charging
                 # but should not be started with more than pwr_offgrid if they are full
                 # if a offGrid device need to be started, the output power is set to 0 and it take all offGrid power from grid
-                start_pwr = max(50, min(80, abs(d.charge_limit) * 6 // 100))
+                start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, abs(d.charge_limit) * 6 // 100))
                 await d.power_charge(-start_pwr - max(0, d.pwr_offgrid) if d.state != DeviceState.SOCFULL else -max(0, d.pwr_offgrid))
                 if (dev_start := dev_start - d.charge_optimal * 2) >= 0:
                     break
@@ -621,7 +625,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             self.idle.sort(key=lambda d: d.electricLevel.asInt, reverse=True)
             for d in self.idle:
                 if d.state != DeviceState.SOCEMPTY:
-                    start_pwr = max(50, min(80, d.discharge_limit * 6 // 100))
+                    start_pwr = max(SmartMode.POWER_START + random.randint(0, 10), min(80, d.discharge_limit * 6 // 100))
                     await d.power_discharge(start_pwr)
                     if (dev_start := dev_start - d.discharge_optimal * 2) <= 0:
                         break

--- a/custom_components/zendure_ha/number.py
+++ b/custom_components/zendure_ha/number.py
@@ -40,7 +40,7 @@ class ZendureNumber(EntityZendure, NumberEntity):
         doupdate: bool = False,
     ) -> None:
         """Initialize a number entity."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "number")
         self.entity_description = NumberEntityDescription(
             key=uniqueid,
             name=uniqueid,

--- a/custom_components/zendure_ha/select.py
+++ b/custom_components/zendure_ha/select.py
@@ -28,7 +28,7 @@ class ZendureSelect(EntityZendure, SelectEntity):
 
     def __init__(self, device: EntityDevice, uniqueid: str, options: dict[Any, str], onchanged: Callable | None, current: int | None = None) -> None:
         """Initialize a select entity."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "select")
         self.entity_description = SelectEntityDescription(key=uniqueid, name=uniqueid)
         self._options = options
         self._attr_options = list(options.values())

--- a/custom_components/zendure_ha/sensor.py
+++ b/custom_components/zendure_ha/sensor.py
@@ -42,7 +42,7 @@ class ZendureSensor(EntityZendure, SensorEntity):
         icon: str | None = None,
     ) -> None:
         """Initialize a Zendure entity."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "sensor")
         self.entity_description = SensorEntityDescription(key=uniqueid, name=uniqueid, native_unit_of_measurement=uom, device_class=deviceclass, state_class=stateclass, icon=icon)
         self._value_template: Template | None = template
         if precision is not None:

--- a/custom_components/zendure_ha/switch.py
+++ b/custom_components/zendure_ha/switch.py
@@ -36,7 +36,7 @@ class ZendureSwitch(EntityZendure, SwitchEntity):
         value: bool | None = None,
     ) -> None:
         """Initialize a switch entity."""
-        super().__init__(device, uniqueid)
+        super().__init__(device, uniqueid, "switch")
         self.entity_description = SwitchEntityDescription(key=uniqueid, name=uniqueid, device_class=deviceclass)
 
         self._attr_available = True

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -60,9 +60,6 @@
       "wifi_state": {
         "name": "WLAN-Status"
       },
-      "pass": {
-        "name": "Bypass"
-      },
       "heat_state": {
         "name": "Batterieheizung"
       },

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -71,9 +71,6 @@
       "wifi_state": {
         "name": "Wifi State"
       },
-      "pass": {
-        "name": "Bypass"
-      },
       "heat_state": {
         "name": "Battery Heating"
       },

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -76,9 +76,6 @@
       "wifi_state": {
         "name": "État du Wi-Fi"
       },
-      "pass": {
-        "name": "Dérivation ( bypass )"
-      },
       "heat_state": {
         "name": "chauffage de batterie"
       },

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -72,9 +72,6 @@
       "wifi_state": {
         "name": "Wifi Status"
       },
-      "pass": {
-        "name": "Bypass"
-      },
       "heat_state": {
         "name": "batterijverwarming"
       },


### PR DESCRIPTION
- **Self-healing entity cleanup** (entity.py): adds check_entities() to EntityDevice,
  called once after device creation. Removes stale registry entries in the wrong domain
  (e.g. byPass previously as binary_sensor, now sensor) or belonging to none-typed keys.
  No migration bumps needed.
- **Anti-oscillation fix** (device.py): fixes sign error in ZendureZenSdk.charge() guard
  (power -= 10, not += 10); adds matching guard to discharge().
- **Cleanup** (manager.py): call device.check_entities() after device init; simplify
  start_pwr to SmartMode.POWER_START; remove unused import random.
- **Error log** (api.py): replace misleading "Unable to connect" with accurate message.
- **Translations**: remove dead binary_sensor "pass" entry from en/de/fr/nl.