### PR TITLE
Fix state class of energy sensors

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -151,8 +151,8 @@ class ZendureDevice(EntityDevice):
         self.heatState = ZendureBinarySensor(self, "heatState")
         self.hemsState = ZendureBinarySensor(self, "hemsState")
         self.hemsStateUpdated = datetime.min
-        self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
+        self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy_storage", None, 1)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "total", 2)
         self.connectionStatus = ZendureSensor(self, "connectionStatus")
         self.connection: ZendureRestoreSelect
         self.bleAdapter: ZendureRestoreSelect | None = None

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -107,8 +107,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         )
         self.operationstate = ZendureSensor(self, "operation_state")
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 12000, -12000, NumberMode.BOX, True)
-        self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy", "measurement", 2)
+        self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy_storage", None, 1)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "total", 2)
         self.power = ZendureSensor(self, "power", None, "W", "power", "measurement", 0)
 
         # load devices


### PR DESCRIPTION
Avoid error messages like this:
`WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.zendure_manager_total_kwh (<class 'custom_components.zendure_ha.sensor.ZendureSensor'>) is using state class 'measurement' which is impossible considering device class ('energy') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/zendure/zendure-ha/issues`