### PR TITLE
should fix p1 matching when SOCFULL, but grid reverse is disabled

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -125,6 +125,7 @@ class ZendureDevice(EntityDevice):
         self.pwr_produced: int = 0
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
+        self.exports_bypass: bool = True
 
         self.create_entities()
 
@@ -244,6 +245,8 @@ class ZendureDevice(EntityDevice):
                         if self.electricLevel.asInt == 100:
                             self.nextCalibration.update_value(dt_util.now() + timedelta(days=30))
                         self.availableKwh.update_value((self.electricLevel.asNumber - self.minSoc.asNumber) / 100 * self.kWh)
+                    case "gridReverse":
+                        self.exports_bypass = value != 2
         except Exception as e:
             _LOGGER.error("EntityUpdate error %s %s %s!", self.name, key, e)
             _LOGGER.error(traceback.format_exc())

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -428,6 +428,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # get power production
                 d.pwr_produced = min(0, d.batteryOutput.asInt + d.homeInput.asInt - d.batteryInput.asInt - d.homeOutput.asInt)
                 self.produced -= d.pwr_produced
+                grid_reverse_entity = d.entities.get("gridReverse")
+                grid_reverse = grid_reverse_entity.value if isinstance(grid_reverse_entity, ZendureSelect) else None
+                # SOCFULL bypass power should only be accounted when export is allowed
+                # (or the device does not expose gridReverse). With gridReverse=forbidden,
+                # produced solar follows requested output and must not be subtracted again.
+                socfull_bypass = d.state == DeviceState.SOCFULL and grid_reverse in (None, 1, "allow")
 
                 # only positive pwr_offgrid must be taken into account, negative values count a solarInput
                 if (home := -d.homeInput.asInt + max(0, d.pwr_offgrid)) < 0:
@@ -439,7 +445,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
                     self.discharge.append(d)
-                    self.discharge_bypass -= d.pwr_produced if d.state == DeviceState.SOCFULL else 0
+                    self.discharge_bypass -= d.pwr_produced if socfull_bypass else 0
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -428,12 +428,6 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # get power production
                 d.pwr_produced = min(0, d.batteryOutput.asInt + d.homeInput.asInt - d.batteryInput.asInt - d.homeOutput.asInt)
                 self.produced -= d.pwr_produced
-                grid_reverse_entity = d.entities.get("gridReverse")
-                grid_reverse = grid_reverse_entity.value if isinstance(grid_reverse_entity, ZendureSelect) else None
-                # SOCFULL bypass power should only be accounted when export is allowed
-                # (or the device does not expose gridReverse). With gridReverse=forbidden,
-                # produced solar follows requested output and must not be subtracted again.
-                socfull_bypass = d.state == DeviceState.SOCFULL and grid_reverse in (None, 1, "allow")
 
                 # only positive pwr_offgrid must be taken into account, negative values count a solarInput
                 if (home := -d.homeInput.asInt + max(0, d.pwr_offgrid)) < 0:
@@ -445,7 +439,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
                     self.discharge.append(d)
-                    self.discharge_bypass -= d.pwr_produced if socfull_bypass else 0
+                    self.discharge_bypass -= d.pwr_produced if d.state == DeviceState.SOCFULL and d.exports_bypass else 0
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced


### PR DESCRIPTION
ie. request only whats required from the solar panels, when theres more solar available then required