### PR TITLE
Correct power start value for solarflow 2400 AC+

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -69,5 +69,5 @@ class SmartMode:
 
     HEMSOFF_TIMEOUT = 60  # Seconds before HEMS state is set to OFF if no updates are received
 
-    POWER_START = 50  # Minimum Power (W) for starting a device
+    POWER_START = 60  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating


### PR DESCRIPTION
This change updates the minimum power required to start charging from 50W to 60W for the SolarFlow 2400 AC+.

The previous threshold could fail to trigger charging.

This adjustment may also be applicable to the SolarFlow 2400 AC, but has only been validated on the AC+ model.