### PR TITLE
Correct error 'ZendureNumber' object has no attribute 'asInt'

### DIFF
--- a/custom_components/zendure_ha/number.py
+++ b/custom_components/zendure_ha/number.py
@@ -96,6 +96,11 @@ class ZendureNumber(EntityZendure, NumberEntity):
         """Return the current value of the sensor."""
         return self._attr_native_value if isinstance(self._attr_native_value, (int, float)) else 0
 
+    @property
+    def asInt(self) -> int:
+        """Return the current value as int."""
+        return int(self._attr_native_value) if isinstance(self._attr_native_value, (int, float)) else 0
+
 
 class ZendureRestoreNumber(ZendureNumber, RestoreEntity):
     """Representation of a Zendure number entity with restore."""


### PR DESCRIPTION
Correct error in 1.30 that failed to start charge or discharge because of that : 

`Traceback (most recent call last): File "/config/custom_components/zendure_ha/manager.py", line 412, in _p1_changed await self.powerChanged(p1, isFast, time) File "/config/custom_components/zendure_ha/manager.py", line 475, in powerChanged await self.power_charge(setpoint, time) File "/config/custom_components/zendure_ha/manager.py", line 565, in power_charge await d.power_charge(-start_pwr - max(0, d.pwr_offgrid) if d.state != DeviceState.SOCFULL else -max(0, d.pwr_offgrid)) File "/config/custom_components/zendure_ha/device.py", line 620, in power_charge return await self.charge(power) ^^^^^^^^^^^^^^^^^^^^^^^^ File "/config/custom_components/zendure_ha/device.py", line 741, in charge if power == -SmartMode.POWER_START and self.limitInput.asInt == -SmartMode.POWER_START and self.homeInput.asInt == 0: ^^^^^^^^^^^^^^^^^^^^^ AttributeError: 'ZendureNumber' object has no attribute 'asInt'`