### PR TITLE
Fix total_kwh state_class and silence empty-sentinel warning

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -152,7 +152,7 @@ class ZendureDevice(EntityDevice):
         self.hemsState = ZendureBinarySensor(self, "hemsState")
         self.hemsStateUpdated = datetime.min
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy_storage", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "total", 2)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "measurement", 2)
         self.connectionStatus = ZendureSensor(self, "connectionStatus")
         self.connection: ZendureRestoreSelect
         self.bleAdapter: ZendureRestoreSelect | None = None

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -63,7 +63,8 @@ class EntityZendure(Entity):
         self._attr_should_poll = False
         self._attr_available = True
         if device is None:
-            _LOGGER.warning("Entity %s has no device, skipping initialization.", uniqueid)
+            if uniqueid != "empty":
+                _LOGGER.warning("Entity %s has no device, skipping initialization.", uniqueid)
             return
         self.device = device
         self.propertyName = uniqueid

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -108,7 +108,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.operationstate = ZendureSensor(self, "operation_state")
         self.manualpower = ZendureRestoreNumber(self, "manual_power", None, None, "W", "power", 12000, -12000, NumberMode.BOX, True)
         self.availableKwh = ZendureSensor(self, "available_kwh", None, "kWh", "energy_storage", None, 1)
-        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "total", 2)
+        self.totalKwh = ZendureSensor(self, "total_kwh", None, "kWh", "energy_storage", "measurement", 2)
         self.power = ZendureSensor(self, "power", None, "W", "power", "measurement", 0)
 
         # load devices


### PR DESCRIPTION
- total_kwh used state_class "total" with device_class "energy_storage", which HA rejects. Switched to "measurement" since total_kwh is a capacity reading, not an accumulator. Batteries can be added **and** removed
- The intentional EntityDevice.empty sentinel was triggering the "Entity has no device" warning at module load. Skip the warning for that known uniqueid; keep it for genuine misuse.