### PR TITLE
Fix discharge_bypass interactions with non-SOCFULL devices

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -459,12 +459,20 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.availableKwh.update_value(availableKwh)
 
         # discharge_bypass accumulates the solar-only power produced by SOCFULL devices.
-        # Subtract it from setpoint to avoid over-discharging from grid, but clamp so
-        # setpoint never goes below 0 when p1 >= 0: a SOCFULL device producing solar
-        # should still cover home demand, not trigger charge mode (fixes #1151 output
-        # cycling to 0W with bypass forbidden + 100% SoC).
+        # SOCFULL homeOutput is solar passthrough, not battery discharge, so it must be
+        # backed out of setpoint. How depends on what other devices are available:
+        #   - charge target present: subtract fully and let setpoint go negative so
+        #     power_charge() ramps the absorber to match the surplus.
+        #   - only SOCFULL devices in the discharge bucket: preserve #1151 — floor
+        #     setpoint at 0 when p1 >= 0 so SOCFULL devices aren't asked to charge.
+        #   - non-SOCFULL discharger present: skip the subtraction entirely. It would
+        #     force convergence to p1 = bypass (steady-state grid import equal to the
+        #     SOCFULL solar) when the non-SOCFULL device could close that gap.
         if self.discharge_bypass > 0:
-            setpoint = max(0 if p1 >= 0 else setpoint - self.discharge_bypass, setpoint - self.discharge_bypass)
+            if self.charge:
+                setpoint -= self.discharge_bypass
+            elif all(d.state == DeviceState.SOCFULL for d in self.discharge):
+                setpoint = max(0 if p1 >= 0 else setpoint - self.discharge_bypass, setpoint - self.discharge_bypass)
 
         # Update power distribution.
         _LOGGER.info("P1 ======> p1:%s isFast:%s, setpoint:%sW stored:%sW", p1, isFast, setpoint, self.produced)
@@ -576,10 +584,15 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             self.charge_time = datetime.max
             self.pwr_low = 0
 
-        # stop charging devices
-        for d in self.charge:
-            # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
-            await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
+        # stop charging devices when entering discharge mode.
+        # Gate on POWER_START only when discharge devices are present: a small positive
+        # setpoint can arise from SOCFULL bypass contributions (not genuine import), and
+        # stopping an in-flight charge in that case causes oscillation. Without discharge
+        # devices the setpoint reflects genuine grid import, so always stop then.
+        if not self.discharge or setpoint > SmartMode.POWER_START:
+            for d in self.charge:
+                # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
+                await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
 
         # distribute discharging devices, use produced power first, before adding another device
         dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0


### PR DESCRIPTION
Fixes #1302. Probably also fixes #1312, depending on the reporter's setup — same symptom shape. #1304 may sound similar, but is definitely not fixed by this.

## Background

#1151 reported SOCFULL Hypers (bypass forbidden) cycling output to 0W: with the original `setpoint -= self.discharge_bypass`, setpoint could flip sign when home demand was below the SOCFULL bypass solar, sending the manager into `power_charge()` against devices that physically couldn't accept charge.

#1162 fixed it by clamping the result at 0 when `p1 ≥ 0`. This works for the #1151 topology (SOCFULL devices, no other absorber/discharger), but is too coarse for the rest of the configuration space — the clamp now runs whether or not other non-SOCFULL devices are present, and that introduces two new failure modes.

## Regressions introduced by #1162

**Charge-side oscillation.** With SOCFULL Hypers passing solar and a non-SOCFULL absorber (e.g. SolarFlow 2400 AC) trying to take the surplus, the absorber's draw flips P1 slightly positive. The clamp's `max(0, …)` then zeroes setpoint — the manager calls `power_discharge(0)`, which tears down the in-flight charge. ~60–90s cycle, never sustains charging.

<details>
<summary>Log excerpt: charge-side oscillation (one cycle, ~100s)</summary>

```
12:02:10  P1 ======> p1:-403  isFast:False  setpoint:-403W
12:02:10  Charge => setpoint -403W
12:02:10  Power charge SolarFlow 2400 AC => -60     ← ramp starts
12:02:26  P1 ======> p1:-339  isFast:False  setpoint:-398W
12:02:26  Power charge SolarFlow 2400 AC => -398    ← full charge
12:02:33  P1 ======> p1:-115  isFast:True   setpoint:-431W
12:02:33  Power charge SolarFlow 2400 AC => -431
12:02:43  P1 ======> p1:+42   isFast:False  setpoint:0W      ← clamp forces 0
12:02:43  Discharge => setpoint 0W
12:02:43  Power discharge SolarFlow 2400 AC => 0    ← charge torn down
12:02:52  Charge => setpoint -360W
12:02:52  Power charge SolarFlow 2400 AC => 0       ← hysteresis lockout
12:02:59  Charge => setpoint -406W                  ← no power command
12:03:13  Charge => setpoint -405W                  ← no power command
12:03:27  Charge => setpoint -407W                  ← no power command
12:03:41  Charge => setpoint -405W                  ← no power command
12:03:52  Power charge SolarFlow 2400 AC => -60     ← cycle restarts
```

</details>

**Steady-state grid import.** Mirror case: heavy load + SOCFULL Hypers + non-SOCFULL discharger. The subtraction makes setpoint converge to `home − bypass` in steady state, so p1 parks at the SOCFULL solar production amount instead of 0. The non-SOCFULL device could close the gap but is never asked to.

<details>
<summary>Log excerpt: steady-state grid import (~6 ticks)</summary>

```
13:48:32  P1 ======> p1:374  setpoint:1722W  stored:367W
13:48:32  Power discharge SolarFlow 2400 AC => 790
13:48:32  Power discharge Hyper 2000 SE     => 466
13:48:32  Power discharge Hyper 2000 SW     => 471
13:48:41  P1 ======> p1:394  setpoint:1756W  stored:369W
13:48:52  P1 ======> p1:391  setpoint:1783W  stored:370W
13:49:04  P1 ======> p1:390  setpoint:1815W  stored:367W
13:49:15  P1 ======> p1:386  setpoint:1842W  stored:368W
```

p1 hovers at ~+385W while setpoint slowly climbs — the system is converging to `p1 = bypass` rather than `p1 = 0`. The `stored:367W` reading is dominated by the two SOCFULL Hypers' solar passthrough, so `bypass ≈ 367W ≈ p1`.

</details>


## Fix

Split the clamp by topology and gate the discharge-side teardown of in-flight charges:

1. **`discharge_bypass` becomes three-branched** in `manager.py`:
   - charge target present → subtract fully, let setpoint go negative so the absorber tracks the surplus.
   - only SOCFULL devices in discharge (#1151's exact topology) → floor at 0 when `p1 ≥ 0`. Identical to today's behavior.
   - non-SOCFULL discharger present → don't subtract; the non-SOCFULL device can absorb the deficit.

2. **Gate the "stop charging devices" loop** at the top of `power_discharge` on `setpoint > SmartMode.POWER_START`. Without this, even with (1) in place a small positive setpoint during the absorber's ramp-up still calls into `power_discharge`, which would unconditionally tear the charge down. Aligns with the threshold the rest of the function already uses to gate `dev_start`.

## Behavior

| scenario | branch hit | result |
|---|---|---|
| #1151 (SOCFULL only, no absorber) | `elif` | identical to today |
| Charge + SOCFULL bypass + non-SOCFULL absorber | `if` | clamp subtracts; setpoint allowed < 0 |
| Discharge + SOCFULL + non-SOCFULL discharger | clamp skipped | converges to p1 ≈ 0 |
| Pure non-SOCFULL discharge | outer cond. false | unchanged |

Reproduced on 2× Hyper 2000 + 1× SolarFlow 2400 AC: no more charge oscillation, p1 converges to ±5W under heavy load, no regression on transient swings.

## Not addressed

The residual issue @Herr-Frodo flagged on #1162 ("AC output stucks at value of POWER_START from constant.py per device") is in a separate code path in the discharge distribution loop (`pwr_low` accounting / per-device clamping) and is unaffected by this PR. #1151's exact topology is left bit-for-bit unchanged.
