### PR TITLE
Avoid grid round-trip when charge target can't overcome off-grid pull

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -550,6 +550,17 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 self.pwr_low = 0 if (delta := d.charge_start * 1.5 - pwr) >= 0 else self.pwr_low + int(-delta)
                 pwr = 0 if self.pwr_low < d.charge_optimal else pwr
 
+            # In acMode=1 the off-grid outlet is sourced from grid alongside
+            # battery charge, so homeInput ≈ |pwr| + pwr_offgrid. If the share
+            # we'd charge doesn't exceed the offgrid pull, the offgrid leg
+            # dominates and the surplus we wanted to absorb turns into net
+            # import. Switch to acMode=2 so battery supplies offgrid; the
+            # outputLimit=10 (vs 0) keeps the device in the discharge bucket
+            # next refresh instead of being reclassified as charging.
+            if d.pwr_offgrid > 0 and pwr > -d.pwr_offgrid:
+                await d.power_discharge(10)
+                continue
+
             setpoint -= await d.power_charge(pwr)
             dev_start += -1 if pwr != 0 and d.electricLevel.asInt > self.idle_lvlmin + 3 else 0
 


### PR DESCRIPTION
When a device with an active off-grid AC outlet is in `acMode=1` (charge), the device sources **both** battery charging and the off-grid load from `gridInputPower`, so `homeInput ≈ |pwr| + pwr_offgrid`. If the assigned charge target `|pwr|` is smaller than `pwr_offgrid`, sending the charge command makes the system import `pwr_offgrid + |pwr|` to absorb a `|pwr|`-sized surplus — net grid import goes *up*, not down.

This patch detects that regime in `power_charge()` and swaps the device to `acMode=2 outputLimit=10` instead, so the battery supplies its own off-grid load and the small surplus feeds home directly. Large surpluses (`|pwr| > pwr_offgrid`) still charge normally — the swap is gated on `pwr > -d.pwr_offgrid`.

## Reproducing

Two Hypers + SolarFlow 2400 AC with an off-grid load (~30W). With Hyper feed-to-grid set to `forbidden`, the autonomous solar feed stops, exposing the SF's off-grid pull on the P1 meter. System steady-state observed:
```
P1 ======> p1:45 isFast:False, setpoint:-14W stored:25W
Charge => setpoint -14W
Power charge SolarFlow 2400 AC => -14
```

`setpoint − p1 = -59` ⇒ `SF.homeInput ≈ 59W = ~14W battery charge + ~45W gridOffPower`. The system commands -14W of battery charge, which drags 45W of off-grid pull along with it — `p1` settles at ≈`gridOffPower` instead of 0.

## When the swap fires

The swap only fires when the assigned charge target is smaller than the device's off-grid pull (`|pwr| < pwr_offgrid`). In that regime — typically when no upstream device is supplying home demand, e.g. when feed-to-grid is forbidden — `acMode=1` would source the off-grid leg from grid alongside the battery charge, so charging amplifies grid import rather than absorbing surplus. Outside that regime (`|pwr| ≥ pwr_offgrid`, e.g. during meaningful solar absorption), the device charges normally.

## Scope of behavior change

- Per-device check inside the charge distribution loop, gated on `d.pwr_offgrid > 0 AND pwr > -d.pwr_offgrid`.
- Large solar absorption is untouched: setpoint of -1262W with `pwr_offgrid=45W` gives `pwr=-1262`, `-1262 > -45` is false, normal charge path runs.
- Devices without an off-grid outlet (`pwr_offgrid == 0`) are unaffected — `pwr_offgrid > 0` short-circuits the check.
- Existing precedent for `power_discharge(10)` on off-grid charge devices: same value, same intent (avoid reclassification as charging on next refresh).

## Result

Same test scenario, after fix: `p1` settles to ≈ `-house_solar` (small feed-in) instead of `+pwr_offgrid` consumption — closer to zero in absolute terms, and no longer paying for the off-grid load through the grid meter.
