### PR TITLE
Smooth P1 with rolling average to dampen control overshoot

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -408,7 +408,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 self.produced = 0
                 for fg in self.fuseGroups:
                     fg.initPower = True
-                await self.powerChanged(p1, isFast, time)
+                # Pass an averaged p1 to dampen proportional overshoot from the
+                # control loop's per-cycle re-distribution. On a fast change the
+                # history was just cleared and holds only the current sample, so
+                # the average equals p1 — fast updates stay responsive.
+                p1_smooth = int(sum(self.p1_history) / len(self.p1_history))
+                await self.powerChanged(p1_smooth, isFast, time)
             except Exception as err:
                 _LOGGER.error(err)
                 _LOGGER.error(traceback.format_exc())


### PR DESCRIPTION
The manager re-issues device commands on every P1 sample, but device output follows with ~1-2 s of firmware lag (Hyper 2000 in my case). Reacting to raw P1 makes each correction overshoot into the next cycle's reading, and the loop never settles — observed as ±50 W of steady-state jitter.

This pull request makes it so we use the mean of the rolling 8-sample p1_history as the setpoint input. This trades ~20 s of phase lag for roughly 3× less amplitude. The fast-update path is unaffected: when isFast fires, p1_history is cleared and the mean equals the new sample, so genuine load steps still get an immediate response.
