### PR TITLE
Force-charge ACE 1500 in UPS mode below reserve target

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -644,6 +644,13 @@ class ZendureDevice(EntityDevice):
         """Get the offgrid power."""
         return 0
 
+    @property
+    def ups_mode(self) -> bool:
+        """True when the device is acting as a UPS (grid passthrough with
+        battery backup). The manager uses this to maintain a charge reserve
+        from grid when no surplus is available."""
+        return False
+
 
 class ZendureLegacy(ZendureDevice):
     """Zendure Legacy class for devices."""

--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -21,6 +21,15 @@ class ACE1500(ZendureLegacy):
         self.acSwitch = ZendureSwitch(self, "acSwitch", self.entityWrite, None, "switch",1)
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
 
+    @property
+    def ups_mode(self) -> bool:
+        """ACE 1500 reports packState=3 when AC input is available — i.e. the
+        AC load runs as grid passthrough with the battery on standby for an
+        outage. packState falls to 2 (discharging) when AC is disconnected,
+        and to 0 (sleeping) when DC input takes over."""
+        pack_state = self.entities.get("packState")
+        return pack_state is not None and pack_state.asInt == 3
+
     async def charge(self, power: int) -> int:
         _LOGGER.info("Power charge %s => %s", self.name, power)
         self.mqttInvoke(

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -628,3 +628,15 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     if (dev_start := dev_start - d.discharge_optimal * 2) <= 0:
                         break
             self.pwr_low: int = 0
+
+        # Force-charge UPS-mode devices that have drifted below their reserve
+        # target. Target is the midpoint between minSoc and socSet, keeping
+        # half the usable capacity in reserve for a grid outage. Runs after
+        # the regular dispatch so this command wins over the power_discharge(0)
+        # the top loop sent.
+        for d in self.devices:
+            if not d.online or not d.ups_mode:
+                continue
+            target = (d.minSoc.asNumber + d.socSet.asNumber) / 2
+            if d.electricLevel.asNumber < target:
+                await d.power_charge(-SmartMode.POWER_START)

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -299,6 +299,20 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.update_count += 1
         self.totalKwh.update_value(kwh)
 
+        # Force-charge UPS-mode devices that have drifted below their reserve
+        # target. Target is the midpoint between minSoc and socSet, keeping
+        # half the usable capacity in reserve for a grid outage. Runs every
+        # SCAN_INTERVAL so it covers all manager modes (OFF, MATCHING with
+        # surplus, MATCHING_CHARGE, STORE_SOLAR, MANUAL with negative power)
+        # — UPS reserve is a hard constraint independent of how the manager
+        # is otherwise dispatching power.
+        for device in self.devices:
+            if not device.online or not device.ups_mode:
+                continue
+            target = (device.minSoc.asNumber + device.socSet.asNumber) / 2
+            if device.electricLevel.asNumber < target:
+                await device.power_charge(-SmartMode.POWER_START)
+
         # Manually update the timer
         if self.hass and self.hass.loop.is_running():
             self._schedule_refresh()
@@ -628,15 +642,3 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     if (dev_start := dev_start - d.discharge_optimal * 2) <= 0:
                         break
             self.pwr_low: int = 0
-
-        # Force-charge UPS-mode devices that have drifted below their reserve
-        # target. Target is the midpoint between minSoc and socSet, keeping
-        # half the usable capacity in reserve for a grid outage. Runs after
-        # the regular dispatch so this command wins over the power_discharge(0)
-        # the top loop sent.
-        for d in self.devices:
-            if not d.online or not d.ups_mode:
-                continue
-            target = (d.minSoc.asNumber + d.socSet.asNumber) / 2
-            if d.electricLevel.asNumber < target:
-                await d.power_charge(-SmartMode.POWER_START)


### PR DESCRIPTION
When an ACE 1500 is set up as a UPS — AC input connected, AC output serving the load — the manager has no way to top up the battery from grid when there's no surplus. Reserve drifts to minSoc and stays there, defeating the point of UPS mode (a power outage finds the battery empty).

This pull request add a `ups_mode` property on the base ZendureDevice (default False) and overrides it on ACE1500 to detect `packState == 3`, the firmware-level signal that AC input is available and the device is running passthrough. After the regular discharge dispatch, we now scan for UPS-mode devices below the midpoint of `[minSoc, socSet]` and command them to charge at POWER_START (60 W) from grid. The pass runs at the end of `power_discharge` so it overrides the `power_discharge(0)` the top loop sends to charge-bucket members.

Reserve target = midpoint keeps half the usable capacity for outage backup without holding the battery near 100 %. POWER_START as the charge rate is gentle on the device fans (no nighttime fan noise) and modest on grid use even with multiple ACEs topping up at once. Stateless: no Schmitt trigger between `minSoc` and `target` — small self-consumption drift re-triggers a small top-up rather than letting SoC fall all the way to minSoc first.

This pull request is related to #1256, which discusses ACE 1500 UPS scenarios. It addresses the "keep the battery reserve charged from grid" half of the workflow @Popoboxxo described; the discharge-regulation half remains open.
