### PR TITLE
Make ACE 1500 controllable without a Hub

### DIFF
--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -144,15 +144,18 @@ class ACE1500(ZendureLegacy):
         and rate-limiting. Each property write goes to the ACE 1500's flash
         memory, so an unguarded 5-second control loop would burn through
         endurance in months. Quantize to 50 W steps and throttle to one
-        write per 30 s. target=0 (stop charging) is exempted from the rate
-        limit so we can drop charging promptly when surplus disappears."""
+        write per 30 s — applies uniformly to start and stop so a surplus
+        that briefly crosses the quantization step doesn't trigger a
+        50W-write immediately followed by a 0W-write. The cost is that a
+        sustained drop in surplus keeps the device drawing its last
+        commanded value for up to one interval; that's bounded and small,
+        and worth it for flash endurance."""
         target = (target // _INPUT_LIMIT_STEP_W) * _INPUT_LIMIT_STEP_W
         now = datetime.now()
         if target == self._last_input_limit:
             return
         if (
-            target != 0
-            and self._last_input_limit is not None
+            self._last_input_limit is not None
             and now - self._last_input_limit_time < _INPUT_LIMIT_MIN_INTERVAL
         ):
             return

--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -1,6 +1,7 @@
 """Module for the ACE1500 device integration in Home Assistant."""
 
 import logging
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -10,6 +11,12 @@ from custom_components.zendure_ha.select import ZendureRestoreSelect, ZendureSel
 from custom_components.zendure_ha.switch import ZendureSwitch
 
 _LOGGER = logging.getLogger(__name__)
+
+# inputLimit writes go to the ACE 1500's flash memory. Quantize to 50 W
+# steps and throttle to one write per 30s so a long surplus-tracking
+# session doesn't burn through flash endurance.
+_INPUT_LIMIT_STEP_W = 50
+_INPUT_LIMIT_MIN_INTERVAL = timedelta(seconds=30)
 
 
 class ACE1500(ZendureLegacy):
@@ -31,6 +38,10 @@ class ACE1500(ZendureLegacy):
         # Default is "paired" to preserve existing behavior; users without a
         # Hub need to flip this to "standalone" for charge/discharge to work.
         self.hubMode = ZendureRestoreSelect(self, "hubMode", {0: "paired", 1: "standalone"}, None, 0)
+        # Track the last inputLimit value/time so standalone charge writes can
+        # be quantized and rate-limited to protect device flash.
+        self._last_input_limit: int | None = None
+        self._last_input_limit_time = datetime.min
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("Power charge %s => %s", self.name, power)
@@ -94,27 +105,45 @@ class ACE1500(ZendureLegacy):
         )
 
     def _chargeStandalone(self, power: int) -> None:
-        """Standalone path: park the device in autoModel=0 (None program) and
-        drive inputLimit through a properties/write. The Smart Matching /
+        """Standalone charge: park the device in autoModel=0 (None program)
+        and drive inputLimit through a properties/write. Smart Matching /
         Battery Priority / Smart CT modes all need a Hub heartbeat we can't
-        supply, leaving the device in standby — so we route around them."""
-        self._setAutoModelNone()
-        self._messageid += 1
-        self.mqttPublish(
-            self.topic_write,
-            {"properties": {"acMode": 1, "inputLimit": -power}},
-        )
+        supply, so we route around them via direct property writes."""
+        self._writeInputLimit(-power)
 
-    def _dischargeStandalone(self, power: int) -> None:
-        """Standalone path: same idea as _chargeStandalone but driving
-        outputLimit, with inputLimit cleared so the firmware doesn't try to
-        charge simultaneously."""
+    def _dischargeStandalone(self, _power: int) -> None:
+        """Standalone 'discharge' is effectively just stop-charging. The ACE
+        1500 standalone has no AC home output (only off-grid socket / USB /
+        XT-60, none of which the integration can power-control), so the
+        outputLimit property has no effect. We just clear inputLimit to
+        ensure the device isn't pulling from grid."""
+        self._writeInputLimit(0)
+
+    def _writeInputLimit(self, target: int) -> None:
+        """Write inputLimit via properties/write, with quantization
+        and rate-limiting. Each property write goes to the ACE 1500's flash
+        memory, so an unguarded 5-second control loop would burn through
+        endurance in months. Quantize to 50 W steps and throttle to one
+        write per 30 s. target=0 (stop charging) is exempted from the rate
+        limit so we can drop charging promptly when surplus disappears."""
+        target = (target // _INPUT_LIMIT_STEP_W) * _INPUT_LIMIT_STEP_W
+        now = datetime.now()
+        if target == self._last_input_limit:
+            return
+        if (
+            target != 0
+            and self._last_input_limit is not None
+            and now - self._last_input_limit_time < _INPUT_LIMIT_MIN_INTERVAL
+        ):
+            return
         self._setAutoModelNone()
         self._messageid += 1
         self.mqttPublish(
             self.topic_write,
-            {"properties": {"acMode": 2, "outputLimit": max(0, power), "inputLimit": 0}},
+            {"properties": {"inputLimit": target}},
         )
+        self._last_input_limit = target
+        self._last_input_limit_time = now
 
     def _setAutoModelNone(self) -> None:
         """Park the device in autoModel=0 (None program). Standalone ACE 1500

--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -23,7 +23,6 @@ class ACE1500(ZendureLegacy):
     def __init__(self, hass: HomeAssistant, deviceId: str, prodName: str, definition: Any, parent: str | None = None) -> None:
         """Initialise Ace1500."""
         super().__init__(hass, deviceId, prodName, definition["productModel"], definition, parent)
-        self.setLimits(-900, 800)
         self.maxSolar = -900
         self.acSwitch = ZendureSwitch(self, "acSwitch", self.entityWrite, None, "switch",1)
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
@@ -37,11 +36,32 @@ class ACE1500(ZendureLegacy):
         #     can't supply, so they sit in standby when no Hub is present.
         # Default is "paired" to preserve existing behavior; users without a
         # Hub need to flip this to "standalone" for charge/discharge to work.
-        self.hubMode = ZendureRestoreSelect(self, "hubMode", {0: "paired", 1: "standalone"}, None, 0)
+        self.hubMode = ZendureRestoreSelect(self, "hubMode", {0: "paired", 1: "standalone"}, self._onHubModeChange, 0)
         # Track the last inputLimit value/time so standalone charge writes can
         # be quantized and rate-limited to protect device flash.
         self._last_input_limit: int | None = None
         self._last_input_limit_time = datetime.min
+        # Initial limits set for the default (paired) mode. _onHubModeChange
+        # will adjust them after state restore if hubMode comes back as
+        # "standalone".
+        self.setLimits(-900, 800)
+
+    async def _onHubModeChange(self, select: Any, _value: Any) -> None:
+        """Adjust device limits when the user toggles hubMode. Standalone
+        mode has no AC home output (off-grid socket / USB / XT-60 only), so
+        discharge_limit must be 0 — otherwise the manager would distribute
+        home-discharge demand to this device, expecting up to 800 W of
+        contribution that never materializes, and the other devices would
+        under-discharge to compensate.
+
+        Read the current value off `select` rather than `self.hubMode`:
+        this callback fires from `ZendureRestoreSelect.async_added_to_hass`
+        during state restore, which can run before `self.hubMode = ...`
+        finishes assigning on the device."""
+        if select.value == 1:
+            self.setLimits(-900, 0)
+        else:
+            self.setLimits(-900, 800)
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("Power charge %s => %s", self.name, power)

--- a/custom_components/zendure_ha/devices/ace1500.py
+++ b/custom_components/zendure_ha/devices/ace1500.py
@@ -6,7 +6,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from custom_components.zendure_ha.device import ZendureLegacy
-from custom_components.zendure_ha.select import ZendureSelect
+from custom_components.zendure_ha.select import ZendureRestoreSelect, ZendureSelect
 from custom_components.zendure_ha.switch import ZendureSwitch
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,9 +20,38 @@ class ACE1500(ZendureLegacy):
         self.maxSolar = -900
         self.acSwitch = ZendureSwitch(self, "acSwitch", self.entityWrite, None, "switch",1)
         self.dcSwitch = ZendureSelect(self, "dcSwitch", {0: "off", 1: "on"}, self.entityWrite, 1)
+        # Hub-paired vs standalone control mode. The ACE 1500 firmware accepts
+        # different command shapes depending on whether a Hub is driving it:
+        #   - paired: Smart Matching (autoModel=8) with chargingPower in
+        #     autoModelValue, the historical integration default.
+        #   - standalone: autoModel=0 (None program) with direct
+        #     inputLimit/outputLimit property writes. Smart Matching/Battery
+        #     Priority/Smart CT modes all need a Hub heartbeat the integration
+        #     can't supply, so they sit in standby when no Hub is present.
+        # Default is "paired" to preserve existing behavior; users without a
+        # Hub need to flip this to "standalone" for charge/discharge to work.
+        self.hubMode = ZendureRestoreSelect(self, "hubMode", {0: "paired", 1: "standalone"}, None, 0)
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("Power charge %s => %s", self.name, power)
+        if self.hubMode.value == 1:
+            self._chargeStandalone(power)
+        else:
+            self._chargeViaHub(power)
+        return power
+
+    async def discharge(self, power: int) -> int:
+        _LOGGER.info("Power discharge %s => %s", self.name, power)
+        if self.hubMode.value == 1:
+            self._dischargeStandalone(power)
+        else:
+            self._dischargeViaHub(power)
+        return power
+
+    def _chargeViaHub(self, power: int) -> None:
+        """Hub-paired path: Smart Matching mode (autoModel=8) with the charge
+        target carried in autoModelValue.chargingPower. The Hub's periodic
+        commands keep the device acting on the value."""
         self.mqttInvoke(
             {
                 "arguments": [
@@ -41,10 +70,10 @@ class ACE1500(ZendureLegacy):
                 "function": "deviceAutomation",
             }
         )
-        return power
 
-    async def discharge(self, power: int) -> int:
-        _LOGGER.info("Power discharge %s => %s", self.name, power)
+    def _dischargeViaHub(self, power: int) -> None:
+        """Hub-paired path: Smart Matching with discharge target carried in
+        autoModelValue.outPower."""
         self.mqttInvoke(
             {
                 "arguments": [
@@ -63,7 +92,52 @@ class ACE1500(ZendureLegacy):
                 "function": "deviceAutomation",
             }
         )
-        return power
+
+    def _chargeStandalone(self, power: int) -> None:
+        """Standalone path: park the device in autoModel=0 (None program) and
+        drive inputLimit through a properties/write. The Smart Matching /
+        Battery Priority / Smart CT modes all need a Hub heartbeat we can't
+        supply, leaving the device in standby — so we route around them."""
+        self._setAutoModelNone()
+        self._messageid += 1
+        self.mqttPublish(
+            self.topic_write,
+            {"properties": {"acMode": 1, "inputLimit": -power}},
+        )
+
+    def _dischargeStandalone(self, power: int) -> None:
+        """Standalone path: same idea as _chargeStandalone but driving
+        outputLimit, with inputLimit cleared so the firmware doesn't try to
+        charge simultaneously."""
+        self._setAutoModelNone()
+        self._messageid += 1
+        self.mqttPublish(
+            self.topic_write,
+            {"properties": {"acMode": 2, "outputLimit": max(0, power), "inputLimit": 0}},
+        )
+
+    def _setAutoModelNone(self) -> None:
+        """Park the device in autoModel=0 (None program). Standalone ACE 1500
+        only supports autoModel values 0/7/10; the others (6, 8, 9) require a
+        paired Hub. None is the simplest fit for direct external control."""
+        self.mqttInvoke(
+            {
+                "arguments": [
+                    {
+                        "autoModelProgram": 0,
+                        "autoModelValue": {
+                            "chargingType": 0,
+                            "chargingPower": 0,
+                            "freq": 0,
+                            "outPower": 0,
+                        },
+                        "msgType": 1,
+                        "autoModel": 0,
+                    }
+                ],
+                "function": "deviceAutomation",
+            }
+        )
 
     async def power_off(self) -> None:
         """Set the power off."""

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -362,6 +362,13 @@
           "off": "Aus/Eingang"
         }
       },
+      "hub_mode": {
+        "name": "Hub-Modus",
+        "state": {
+          "paired": "Mit Hub gekoppelt",
+          "standalone": "Eigenständig"
+        }
+      },
       "hems_state": {
         "name": "HEMS-Status",
         "state": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -373,6 +373,13 @@
           "off": "Off/Input"
         }
       },
+      "hub_mode": {
+        "name": "Hub Mode",
+        "state": {
+          "paired": "Paired with Hub",
+          "standalone": "Standalone"
+        }
+      },
       "hems_state": {
         "name": "HEMS State",
         "state": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -334,6 +334,13 @@
           "off": "Marche/Entrée"
         }
       },
+      "hub_mode": {
+        "name": "Mode Hub",
+        "state": {
+          "paired": "Couplé avec Hub",
+          "standalone": "Autonome"
+        }
+      },
       "hems_state": {
         "name": "État HEMS",
         "state": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -278,6 +278,13 @@
           "off": "Uit/Invoer"
         }
       },
+      "hub_mode": {
+        "name": "Hub-modus",
+        "state": {
+          "paired": "Gekoppeld met hub",
+          "standalone": "Standalone"
+        }
+      },
       "hems_state": {
         "name": "HEMS Status",
         "state": {


### PR DESCRIPTION
This pull request adds a `hubMode` toggle to the ACE 1500 device: "paired" (default,
preserves existing behavior) or "standalone" (ACE 1500 not connected to a Hub 1200/2000).

In paired mode, the integration sends Smart Matching commands (autoModel=8) which expect a Hub heartbeat to act on the chargingPower field — historical behavior, kept as default for backward compatibility.

In standalone mode the integration parks the device in autoModel=0 (None program) and drives charge/discharge through inputLimit / outputLimit property writes, the only path the ACE 1500 honors without a Hub.

Standalone mode is required for ACE 1500 owners without a Hub (which is not an uncommon configuration — the ACE 1500 has its own inverter and does not need to dock with Hub 1200/2000).

This pull request fixes the standalone-control half of #1256, addressing the observation by @harrymayr that "the only possibility to control AC charging is with the inputLimit". It is a prerequisite for #1334 to deliver value on standalone ACE 1500s.
