### PR TITLE
Calculate offgrid power instead of trusting an inaccurate sensor

### DIFF
--- a/custom_components/zendure_ha/devices/solarflow2400.py
+++ b/custom_components/zendure_ha/devices/solarflow2400.py
@@ -38,7 +38,7 @@ class SolarFlow2400AC(ZendureZenSdk):
     @property
     def pwr_offgrid(self) -> int:
         """Get the offgrid power."""
-        return self.offGrid.asInt
+        return self.batteryOutput.asInt + self.homeInput.asInt - self.batteryInput.asInt - self.homeOutput.asInt
 
 
 class SolarFlow2400Pro(ZendureZenSdk):


### PR DESCRIPTION
I'm not sure if it's only my SolarFlow 2400 AC, but the AC offgrid power sensor is very inaccurate (~ 25 W off). So I went ahead and changed the `pwr_offgrid` function to return the calculated offgrid power rather than the sensor reading.

If other users suffer from the same problem, this might be a worthwhile change.