### PR TITLE
Add power_discharge deadband

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -71,3 +71,5 @@ class SmartMode:
 
     POWER_START = 60  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
+    CHARGE_DEADBAND_HOLD = 30  # Seconds a small positive setpoint must persist before ramping charge down
+    CHARGE_DEADBAND_GAP = 5  # Seconds of absence from the charge deadband that count as a fresh entry

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -72,4 +72,3 @@ class SmartMode:
     POWER_START = 60  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
     CHARGE_DEADBAND_HOLD = 30  # Seconds a small positive setpoint must persist before ramping charge down
-    CHARGE_DEADBAND_GAP = 5  # Seconds of absence from the charge deadband that count as a fresh entry

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -125,6 +125,8 @@ class ZendureDevice(EntityDevice):
         self.pwr_produced: int = 0
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
+        self.charge_deadband_since: datetime | None = None
+        self.charge_deadband_last: datetime = datetime.min
 
         self.create_entities()
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -126,7 +126,6 @@ class ZendureDevice(EntityDevice):
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
         self.charge_deadband_since: datetime | None = None
-        self.charge_deadband_last: datetime = datetime.min
 
         self.create_entities()
 

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -473,27 +473,27 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 if setpoint < 0:
                     await self.power_charge(setpoint, time)
                 else:
-                    await self.power_discharge(setpoint)
+                    await self.power_discharge(setpoint, p1)
 
             case ManagerMode.MATCHING_DISCHARGE:
                 # Only discharge, do nothing if setpoint is negative
-                await self.power_discharge(max(0, setpoint))
+                await self.power_discharge(max(0, setpoint), p1)
 
             case ManagerMode.MATCHING_CHARGE | ManagerMode.STORE_SOLAR:
                 # Allow discharge of produced power in MATCHING_CHARGE-Mode, otherwise only charge
                 # d.pwr_produced is negative, but self.produced is positive
                 if setpoint > 0 and self.produced > SmartMode.POWER_START and self.operation == ManagerMode.MATCHING_CHARGE:
-                    await self.power_discharge(min(self.produced, setpoint))
+                    await self.power_discharge(min(self.produced, setpoint), p1)
                 # send device into idle-mode
                 elif setpoint > 0:
-                    await self.power_discharge(0)
+                    await self.power_discharge(0, p1)
                 else:
                     await self.power_charge(min(0, setpoint), time)
 
             case ManagerMode.MANUAL:
                 # Manual power into or from home
                 if (setpoint := int(self.manualpower.asNumber)) > 0:
-                    await self.power_discharge(setpoint)
+                    await self.power_discharge(setpoint, p1)
                 else:
                     await self.power_charge(setpoint, time)
 
@@ -566,7 +566,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     break
             self.pwr_low: int = 0
 
-    async def power_discharge(self, setpoint: int) -> None:
+    async def power_discharge(self, setpoint: int, p1: int) -> None:
         """Discharge devices."""
         _LOGGER.info("Discharge => setpoint %sW", setpoint)
         self.operationstate.update_value(ManagerState.DISCHARGE.value if setpoint > 0 and self.discharge else ManagerState.IDLE.value)
@@ -580,10 +580,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         now = datetime.now()
         for d in self.charge:
             # Charge deadband: don't stop a device that is actively balancing the grid (it IS the balance).
-            # If the small positive setpoint persists (solar dropped), ramp the commanded
-            # charge down — but only after CHARGE_DEADBAND_HOLD, so ramp-up jitter doesn't trigger it.
-            # The off-grid pass-through (pwr_offgrid) is preserved as a floor so we don't
-            # starve AC-fed off-grid loads.
+            # If grid import persists while this device is charging, ramp the commanded charge
+            # down using observed p1 — not setpoint, which the discharge_bypass clamp can pin
+            # to 0 even when the import is real. Only after CHARGE_DEADBAND_HOLD, so ramp-up
+            # jitter doesn't trigger it. The off-grid pass-through (pwr_offgrid) is preserved
+            # as a floor so we don't starve AC-fed off-grid loads.
             if setpoint < SmartMode.POWER_START and d.homeInput.asInt > SmartMode.POWER_TOLERANCE:
                 if (now - d.charge_deadband_last).total_seconds() > SmartMode.CHARGE_DEADBAND_GAP:
                     d.charge_deadband_since = now
@@ -591,7 +592,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 if d.charge_deadband_since and (now - d.charge_deadband_since).total_seconds() >= SmartMode.CHARGE_DEADBAND_HOLD:
                     offgrid_floor = max(0, d.pwr_offgrid)
                     battery_charge = max(0, d.limitInput.asInt - offgrid_floor)
-                    reduction = min(setpoint, battery_charge)
+                    # Retire proportional to actual import so we land on balance instead of
+                    # overshooting into export (which would trigger a charge ramp-up the next
+                    # cycle, oscillating). Hold steady at p1 <= 0; sub-tolerance imports are
+                    # absorbed by the device-level no-action check on power_charge.
+                    reduction = min(p1, battery_charge) if p1 > 0 else 0
                     await d.power_charge(-(battery_charge - reduction + offgrid_floor))
                     setpoint -= reduction
                 continue

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -577,8 +577,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         _LOGGER.info("Discharge => setpoint %sW", setpoint)
         self.operationstate.update_value(ManagerState.DISCHARGE.value if setpoint > 0 and self.discharge else ManagerState.IDLE.value)
 
-        # reset hysteria time
-        if self.charge_time != datetime.max:
+        # Reset hysteria only when there is actual discharge demand. At
+        # small/zero setpoints we are in deadband territory and may flip
+        # back to charge next cycle (e.g. due to the discharge_bypass clamp
+        # crossing zero); resetting here would force a fresh 60s blackout
+        # in power_charge that stops the active charge entirely.
+        if self.charge_time != datetime.max and setpoint >= SmartMode.POWER_START:
             self.charge_time = datetime.max
             self.pwr_low = 0
 

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -577,9 +577,27 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             self.pwr_low = 0
 
         # stop charging devices
+        now = datetime.now()
         for d in self.charge:
-            # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
-            await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
+            # Charge deadband: don't stop a device that is actively balancing the grid (it IS the balance).
+            # If the small positive setpoint persists (solar dropped), ramp the commanded
+            # charge down — but only after CHARGE_DEADBAND_HOLD, so ramp-up jitter doesn't trigger it.
+            # The off-grid pass-through (pwr_offgrid) is preserved as a floor so we don't
+            # starve AC-fed off-grid loads.
+            if setpoint < SmartMode.POWER_START and d.homeInput.asInt > SmartMode.POWER_TOLERANCE:
+                if (now - d.charge_deadband_last).total_seconds() > SmartMode.CHARGE_DEADBAND_GAP:
+                    d.charge_deadband_since = now
+                d.charge_deadband_last = now
+                if d.charge_deadband_since and (now - d.charge_deadband_since).total_seconds() >= SmartMode.CHARGE_DEADBAND_HOLD:
+                    offgrid_floor = max(0, d.pwr_offgrid)
+                    battery_charge = max(0, d.limitInput.asInt - offgrid_floor)
+                    reduction = min(setpoint, battery_charge)
+                    await d.power_charge(-(battery_charge - reduction + offgrid_floor))
+                    setpoint -= reduction
+                continue
+            # Stop charging without flipping the device into discharge mode: stay in
+            # charge (acMode=1) with inputLimit equal to the offgrid pass-through floor.
+            await d.power_charge(-max(0, d.pwr_offgrid))
 
         # distribute discharging devices, use produced power first, before adding another device
         dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -454,6 +454,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 availableKwh += d.actualKwh
                 power += d.pwr_offgrid + home + d.pwr_produced
 
+        # Reset the charge-deadband timer for devices that are not currently
+        # classified as charging, so a future re-entry starts a fresh hold.
+        for d in self.devices:
+            if d not in self.charge:
+                d.charge_deadband_since = None
+
         # Update the power entities
         self.power.update_value(power)
         self.availableKwh.update_value(availableKwh)
@@ -586,10 +592,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             # jitter doesn't trigger it. The off-grid pass-through (pwr_offgrid) is preserved
             # as a floor so we don't starve AC-fed off-grid loads.
             if setpoint < SmartMode.POWER_START and d.homeInput.asInt > SmartMode.POWER_TOLERANCE:
-                if (now - d.charge_deadband_last).total_seconds() > SmartMode.CHARGE_DEADBAND_GAP:
+                if d.charge_deadband_since is None:
                     d.charge_deadband_since = now
-                d.charge_deadband_last = now
-                if d.charge_deadband_since and (now - d.charge_deadband_since).total_seconds() >= SmartMode.CHARGE_DEADBAND_HOLD:
+                elif (now - d.charge_deadband_since).total_seconds() >= SmartMode.CHARGE_DEADBAND_HOLD:
                     offgrid_floor = max(0, d.pwr_offgrid)
                     battery_charge = max(0, d.limitInput.asInt - offgrid_floor)
                     # Retire proportional to actual import so we land on balance instead of
@@ -600,8 +605,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     await d.power_charge(-(battery_charge - reduction + offgrid_floor))
                     setpoint -= reduction
                 continue
-            # Stop charging without flipping the device into discharge mode: stay in
-            # charge (acMode=1) with inputLimit equal to the offgrid pass-through floor.
+            # Out of the deadband condition — clear the timer so a future re-entry
+            # starts a fresh hold. Stop charging without flipping the device into
+            # discharge mode: stay in charge (acMode=1) with inputLimit equal to
+            # the offgrid pass-through floor.
+            d.charge_deadband_since = None
             await d.power_charge(-max(0, d.pwr_offgrid))
 
         # distribute discharging devices, use produced power first, before adding another device


### PR DESCRIPTION
This pull request replaces #1318.
Fixes #1302.

By adding a `power_discharge` deadband, the AC charging/discharging oscillation in the case of solar surplus stabilizes.