### PR TITLE
Classify devices with active off-grid load as discharge candidates

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -447,6 +447,14 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.discharge_produced -= d.pwr_produced
                     self.discharge_weight += d.pwr_max * d.electricLevel.asInt
                     setpoint += home
+                    # When a device is in discharge only because of pwr_offgrid (no home output),
+                    # it can still absorb surplus from another device's SOCFULL bypass. Expose it
+                    # as an idle candidate too, so power_charge can engage it before a sibling
+                    # device starts charging autonomously from AC.
+                    if home == 0 and d.state != DeviceState.SOCFULL:
+                        self.idle.append(d)
+                        self.idle_lvlmax = max(self.idle_lvlmax, d.electricLevel.asInt)
+                        self.idle_lvlmin = min(self.idle_lvlmin, d.electricLevel.asInt)
 
                 else:
                     self.idle.append(d)

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -436,8 +436,10 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge_optimal += d.charge_optimal
                     self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
                     setpoint += -d.homeInput.asInt  # use gridInputPower directly; offgrid consumers are invisible to P1
-                # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
-                elif (home := d.homeOutput.asInt) > 0:
+                # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid.
+                # Also classify as discharge when the device has an off-grid load: on devices like the SF 2400 AC, outputHomePower reads 0
+                # even while the device is autonomously back-feeding the grid, so pwr_offgrid is our only reliable "device is running" signal.
+                elif (home := d.homeOutput.asInt) > 0 or (d.pwr_offgrid > 0 and d.state != DeviceState.SOCEMPTY):
                     self.discharge.append(d)
                     self.discharge_bypass -= d.pwr_produced if d.state == DeviceState.SOCFULL else 0
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)


### PR DESCRIPTION
## Problem

On single-port SolarFlow devices — confirmed on the SF 2400 AC, likely the same family-wide — `outputHomePower` reads 0 and `gridInputPower` also reads 0 even while the device is autonomously back-feeding the grid (verified with an external power sensor on the on-grid plug). The current classifier in `ZendureManager.powerChanged`:

```python
elif (home := d.homeOutput.asInt) > 0:
    self.discharge.append(d)
```

sends such a device to `idle`. With `setpoint < POWER_START`, the discharge loop's idle-wake-up never fires (`dev_start = 0`), so the device sits unaddressed while small residual home demand is supplied by the grid.

In a real session this stuck state persisted for 17+ minutes with the device exporting ~13 W externally but reporting `homeOutput=0`, `homeInput=0`, `pwr_offgrid=22 W`, `acMode=1`.

## Fix

Treat `pwr_offgrid > 0` as a reliable "device is running" signal and route the device into `discharge` even when `homeOutput` reads 0:

```python
elif (home := d.homeOutput.asInt) > 0 or (d.pwr_offgrid > 0 and d.state != DeviceState.SOCEMPTY):
```

`home` stays 0 in the new branch, so `setpoint` is not bumped by an unreliable sensor — we don't pretend to know an export figure that the firmware isn't giving us. The discharge distribution then issues `acMode=2` and the battery covers off-grid + home demand.

## Scope

- Only affects the SolarFlow family that overrides `pwr_offgrid` (SF 800, SF 1600, SF 2400 variants). All other devices (Hyper, AIO, ACE, hubs, SuperBase) inherit `pwr_offgrid = 0` from the base class and are unaffected.
- For SolarFlow devices where `homeOutput > 0` works correctly, the first branch fires first and accounting is unchanged.
- The new branch only fires when `homeOutput == 0` but `pwr_offgrid > 0` — i.e., the gap case where the firmware under-reports.
- `state != SOCEMPTY` guard mirrors the rationale of the surrounding block: don't try to discharge a flat battery.

## Notes

- Independent of #1352 (charge-side deadband) — they compose cleanly: #1352 smooths the charge ramp-down, this PR handles the post-rampdown state when off-grid load remains active.
- Independent of #1359, which touches sign arithmetic in `power_charge`'s no-action check.
- This is a workaround for a firmware reporting bug. The "right" fix would be a sensor we can trust for on-grid back-feed direction; absent that, `pwr_offgrid` is the next-best generic signal.

## Test plan

- [x] Reproduced the stuck-idle state on SF 2400 AC; with the patch the device gets classified as `discharge` and is commanded `acMode=2`, battery covers home demand and off-grid load
- [ ] Confirm no regression on Hyper-only setups (unaffected by construction since `pwr_offgrid == 0`)
- [x] Confirm no regression on SF 800 / SF 1600 setups where `homeOutput` was already populating correctly