### PR TITLE
Cap charge-group homeInput credit at actual grid export

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -435,7 +435,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge_limit += d.fuseGrp.charge_limit(d)
                     self.charge_optimal += d.charge_optimal
                     self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
-                    setpoint += -d.homeInput.asInt  # use gridInputPower directly; offgrid consumers are invisible to P1
+                    # The homeInput credit against setpoint is deferred until after the loop
+                    # so it can be capped at self.produced — see below.
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
                     self.discharge.append(d)
@@ -453,6 +454,18 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
                 availableKwh += d.actualKwh
                 power += d.pwr_offgrid + home + d.pwr_produced
+
+        # Credit charge-group homeInput against the setpoint, but only up to the actual
+        # grid export reported by the meter (max(0, -p1)). When p1 >= 0 the meter says
+        # nothing is being exported, so the charging draw is grid-driven (or off-grid
+        # pass-through the firmware can't satisfy from the device's own solar) and must
+        # be covered by discharge — not credited as surplus absorption.
+        # self.produced is the wrong bound here because it counts solar going to a
+        # device's own battery (e.g. an SF 800 self-charging) as "production", even
+        # though that energy never reaches the home AC bus and therefore can't be
+        # absorbed by another device's charge.
+        charge_homeInput_total = sum(d.homeInput.asInt for d in self.charge)
+        setpoint -= min(charge_homeInput_total, max(0, -p1))
 
         # Update the power entities
         self.power.update_value(power)


### PR DESCRIPTION
## Problem

In `ZendureManager.powerChanged`, every device classified into `self.charge` subtracts its `homeInput` from `setpoint`:

```python
if (home := -d.homeInput.asInt + max(0, d.pwr_offgrid)) < 0:
    self.charge.append(d)
    ...
    setpoint += -d.homeInput.asInt
```

That subtraction is correct when the charging is absorbing real surplus — the discharge side doesn't need to cover what the charger is consuming from the surplus. But when **there's no real surplus**, the draw is grid-driven (or off-grid pass-through the firmware can't satisfy from the device's own solar). Subtracting it then under-commands the discharge target by exactly the grid-driven portion, and the gap persists as grid import.

Two real sessions exhibit this:

**Case 1** — Hyper outputting, 2400 AC drawing for off-grid passthrough:
```
p1=68, setpoint=413, Hyper output 409, 2400 AC homeInput 64 / offgrid 45
   pre-clamp setpoint = 68 + 409 − 64 = 413  → under by 64
   actual demand from grid perspective = 413 + 64 = 477
```
70W of sustained grid import while the Hyper sat at 409W against a real home demand of 480W.

**Case 2** — SF 800 Pro self-charging from solar, two ACE 1500s charging from grid:
```
P1 ======> p1:40 setpoint:-65 stored:700
Power discharge SolarFlow 800 Pro => no action [power 0]
Power charge Ace 1500 Keller => -35
Power charge Ace 1500 Wohnung => -35
```
The SF 800 was consuming 700W of solar to charge its own battery (`batteryInput=700`, `homeOutput=0`), none of it reaching the home bus, yet the manager treated `self.produced=700` as production available to credit the ACEs' grid-driven charging.

## Fix

Defer the `homeInput` credit until after the classification loop and cap it at the actual grid export reported by the meter:

```python
charge_homeInput_total = sum(d.homeInput.asInt for d in self.charge)
setpoint -= min(charge_homeInput_total, max(0, -p1))
```

When the meter shows no export (`p1 >= 0`), the cap is 0 and no charging draw is credited as surplus absorption. When the meter shows export (`p1 < 0`), charging draws can be credited up to that amount — the unambiguous ground truth for "is there real surplus right now".

`self.produced` is the wrong bound here because it counts solar going to a device's own battery as "production", even though that energy never reaches the home AC bus and therefore can't be absorbed by another device's charge. The meter is the right bound.

## Scope

- Touches only the classifier in `powerChanged`. Per-device contribution is unchanged in the loop; the credit is just aggregated and capped after.
- Independent of #1352 (deadband) and #1368 (offgrid-as-discharge); composes cleanly with both.
- No new sensors or constants.

## Test plan

- [x] Case 1 (SF 2400 AC + 2× Hyper 2000): with the 2400 AC drawing 64W off-grid pass-through and `p1=68`, the cap drops the credit from 64W to 0W and the engaged Hyper's discharge target rises from 413W to 477W, eliminating the residual grid import.
- [x] Case 2 (SF 800 Pro + 2× ACE 1500): with the SF 800 self-charging at 700W and `p1=40`, the cap drops the credit from 70W (`self.produced`-bound) to 0W; the setpoint flips from -65W (charge mode, ACEs commanded to charge) to +40W (discharge mode), allowing the SF 800 to be commanded to output 40W and cover the demand.
- [ ] Confirm no regression on real-surplus absorption (`p1 < 0`): the cap then equals `|p1|`, the charging device gets the same effective credit as before (it's absorbing the export). Logic equivalent to the old code in that regime.
- [ ] Confirm no regression in MATCHING_CHARGE / STORE_SOLAR / MANUAL modes (they reuse the same pre-dispatch setpoint).