### PR TITLE
Credit charge-group homeInput only when grid is actually exporting

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -435,7 +435,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge_limit += d.fuseGrp.charge_limit(d)
                     self.charge_optimal += d.charge_optimal
                     self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
-                    setpoint += -d.homeInput.asInt  # use gridInputPower directly; offgrid consumers are invisible to P1
+                    # The homeInput credit against setpoint is applied after the loop,
+                    # gated on the sign of p1 — see below.
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
                     self.discharge.append(d)
@@ -457,6 +458,16 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         # Update the power entities
         self.power.update_value(power)
         self.availableKwh.update_value(availableKwh)
+
+        # Credit charge-group homeInput against setpoint only when the grid meter shows
+        # actual export (p1 < 0). With p1 < 0 the export means home production exceeds
+        # device draw, so each charging device is genuinely absorbing surplus from the
+        # home bus and the discharge side can be reduced accordingly. With p1 >= 0 there
+        # is no export to absorb: the charging draw is grid-driven (or off-grid
+        # pass-through the firmware can't satisfy from the device's own solar) and must
+        # be covered by discharge instead of credited as surplus absorption.
+        if p1 < 0:
+            setpoint -= sum(d.homeInput.asInt for d in self.charge)
 
         # discharge_bypass accumulates the solar-only power produced by SOCFULL devices.
         # Subtract it from setpoint to avoid over-discharging from grid, but clamp so


### PR DESCRIPTION
## Problem

In `ZendureManager.powerChanged`, every device classified into `self.charge` subtracts its `homeInput` from `setpoint`:

```python
if (home := -d.homeInput.asInt + max(0, d.pwr_offgrid)) < 0:
    self.charge.append(d)
    ...
    setpoint += -d.homeInput.asInt
```

That subtraction is correct when the charging is absorbing real surplus — the discharge side doesn't need to cover what the charger is consuming from the surplus. But when **there's no real surplus**, the draw is grid-driven (or off-grid pass-through the firmware can't satisfy from the device's own solar). Subtracting it then under-commands the discharge target by exactly the grid-driven portion, and the gap persists as grid import.

Two real-world sessions exhibit this:

**Scenario A** — Hyper outputting, 2400 AC drawing for off-grid passthrough:
```
p1=68, setpoint=413, Hyper output 409, 2400 AC homeInput 64 / offgrid 45
   classifier subtracts 64  →  setpoint = 413 instead of 477
   real grid-perspective demand = 413 + 64 = 477
```
~70 W of sustained grid import while the Hyper sat at 409 W against a real home demand of 480 W.

**Scenario B** — SF 800 Pro self-charging from solar, two ACE 1500s charging from grid:
```
p1=40, stored=700, setpoint=-65
   SF 800: solar going to its own battery (batteryInput=700, homeOutput=0)
   ACEs: drawing ~70 W from home AC for battery charging
   classifier subtracts 70  →  setpoint = -65 (charge mode) instead of +40 (discharge mode)
```
The SF 800's 700 W of solar never reached the home AC bus, yet the manager treated the ACEs' grid-driven draw as surplus absorption and kept commanding them to charge.

## Fix

Defer the `homeInput` subtraction until after the classification loop, and apply it only when the grid meter shows actual export:

```python
if p1 < 0:
    setpoint -= sum(d.homeInput.asInt for d in self.charge)
```

Behavior is identical to the original whenever `p1 < 0`: the export proves there's real surplus on the home bus, the charging draw is part of how that surplus is being absorbed, and the discharge side gets the full credit. When `p1 >= 0` the meter says nothing is being exported, so there's nothing to credit — the discharge target reflects the full demand including the charging device's home-bus consumption.

## Why p1 sign, not the magnitude

A previous attempt (#1371) capped the credit at `max(0, -p1)`. That under-credits ongoing absorption in steady-state PV-coupled setups, per @harrymayr's example: 3 devices each absorbing 400 W of AC-coupled PV, p1=0 in balance; sun bumps production by 100 W and p1 swings to −100 W. With the `max(0, -p1)` cap the credit would be 100 W → setpoint = −200 W → distributed across 3 devices ≈ 67 W each, cutting absorption from 1200 W to 200 W and dumping ~1000 W to grid. The sign-only gate retains the full 1200 W credit (`setpoint = −1300`, distributed as ≈ 433 W per device) so legitimate absorption isn't clipped.

## Scope

- Touches only the classifier in `powerChanged`. Per-device contribution is unchanged in the loop; the credit is just deferred and gated.
- Independent of #1352 (deadband) and #1368 (offgrid-as-discharge); composes cleanly with both.
- No new sensors or constants.

## Edge case at p1=0

Strict `p1 < 0` means a perfectly-balanced state (devices absorbing exactly the available surplus, p1=0) flips to "no credit" → setpoint becomes positive → discharge-mode at the device's home-bus draw → deadband ramps charging down → resulting export bumps p1 negative → credit restored → charging ramps back up. One or two cycles of transient before settling on a new equilibrium with less charging activity. The existing deadband and `discharge_bypass` clamp make that transition graceful, and the alternative (`p1 <= 0`, full credit at zero) preserves steady-state absorption but blurs the boundary between "surplus" and "balanced". Going with strict `<` here; can be loosened later if the transient turns out to be a problem in practice.

## Test plan

- [x] Scenario A (SF 2400 AC + 2× Hyper 2000): with `p1=68` and 2400 AC drawing 64 W for off-grid passthrough, the credit drops from 64 W to 0 W and the engaged Hyper's discharge target rises from 413 W to 477 W, eliminating the residual grid import.
- [x] Scenario B (SF 800 Pro + 2× ACE 1500): with `p1=40` and SF 800 self-charging at 700 W, the credit drops from 70 W to 0 W; setpoint flips from −65 W (charge mode, ACEs commanded to charge) to +40 W (discharge mode), allowing the SF 800 to be commanded to output 40 W.
- [x] PV-coupled absorption (3 devices × 400 W, p1=0 → p1=−100): credit stays at the full 1200 W when p1 < 0, so distribution still rises proportionally to absorb the additional 100 W.
- [ ] Confirm no regression in MATCHING_CHARGE / STORE_SOLAR / MANUAL modes (they reuse the same pre-dispatch setpoint).