### PR TITLE
Credit charge-group homeInput only up to the battery's accepted input

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -435,7 +435,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.charge_limit += d.fuseGrp.charge_limit(d)
                     self.charge_optimal += d.charge_optimal
                     self.charge_weight += d.pwr_max * (100 - d.electricLevel.asInt)
-                    setpoint += -d.homeInput.asInt  # use gridInputPower directly; offgrid consumers are invisible to P1
+                    # Credit only the portion of homeInput that reaches the battery; AC
+                    # drawn but not stored is real demand on the home bus, not surplus.
+                    setpoint -= min(d.homeInput.asInt, d.batteryInput.asInt)
                 # SOCEMPTY means, it could not discharge the battery, but it is still possible to feed into the home using solarpower or offGrid
                 elif (home := d.homeOutput.asInt) > 0:
                     self.discharge.append(d)


### PR DESCRIPTION
## Problem

In `ZendureManager.powerChanged`, every device classified into `self.charge` subtracts its full `homeInput` from `setpoint`:

```python
if (home := -d.homeInput.asInt + max(0, d.pwr_offgrid)) < 0:
    self.charge.append(d)
    ...
    setpoint += -d.homeInput.asInt
```

This is correct only when the AC draw is actually charging the battery — surplus is being absorbed, and the discharge side legitimately doesn't need to cover it. But the same `homeInput` can persist while the battery accepts less (SOCFULL, thermal throttle, or other firmware behaviors where the AC draw doesn't fully reach the battery). In those cases the unbatteried portion is real demand on the home AC bus, not surplus absorption, and subtracting it under-commands the discharge target by exactly that portion — leaving the gap as grid import.

Two real-world sessions exhibited this:

**Scenario A** — Hyper 2000 outputting, SF 2400 AC drawing while SOCFULL:
```
p1=68, Hyper SE out=409, 2400 AC homeInput=64, batteryInput=0 (SOCFULL)
   classifier subtracts 64  →  setpoint=413 instead of 477
   grid import ~70 W persists because Hyper undershoots the real demand
```

**Scenario B** — SF 800 Pro charging from its own solar, two ACE 1500s drawing from the home bus:
```
p1=40, stored=700 (SF 800 batteryInput=700, homeOutput=0)
   ACEs draw ~100 W combined; classifier subtracts 100  →  setpoint=−65
   charge mode is entered and the ACEs are commanded to charge more
   from grid, even though no surplus reaches the home bus
```

## Fix

Cap each device's credit at the actual energy reaching its battery:

```python
setpoint -= min(d.homeInput.asInt, d.batteryInput.asInt)
```

- When the firmware respects the commanded `inputLimit` and feeds the battery, `homeInput` and `batteryInput` track together and the credit is identical to today (legitimate absorption case, including @harrymayr's PV-coupled scenario with three devices each absorbing 400 W — `setpoint -= 1200` exactly as before).
- When less of the AC draw reaches the battery, the credit shrinks to the actual battery flow, and the non-battery portion correctly falls onto the discharge side as demand to cover.

The signal doesn't depend on `p1`'s sign or magnitude, which sidesteps the failure mode that closed the two earlier attempts: AC charging itself shifts `p1` across zero, so any `p1`-based gate oscillates as soon as a device starts absorbing. `batteryInput` is a per-device measurement of what's physically reaching the cells, so it doesn't move just because we successfully started charging.

## Walking the scenarios

| Case | homeInput | batteryInput | subtract | setpoint | Outcome |
|---|---|---|---|---|---|
| A: 2400 AC drawing while SOCFULL | 64 | 0 | 0 | 68+409−0 = **477** | Hyper covers full demand including 2400 AC's 64 W home-bus draw → p1≈0 |
| B: ACEs charging at 50 W each (battery accepting) | 50 each | 50 each | 100 | 40+0−100 = **−60** | Charge mode at 60 W reduces ACEs 100→60 W → p1=0 |
| Harrymayr's: 3× device absorbing 400 W (battery accepting) | 400 each | 400 each | 1200 | −100+0−1200 = **−1300** | Distributed ~433 W each → absorption rises 1200→1300 W |
| Start-charging transient (idle → 60 → 100) | 0→60→100 | 0→60→100 | 0→60→100 | counterfactual stays at −100 throughout | No oscillation — credit tracks the actual battery flow |

## Credit / history

This PR is the third attempt at the same control-loop bug. The first two — #1371 (cap at `max(0, self.produced)`) and #1378 (sign of `-p1` as a gate) — both relied on signals tied to the device commands themselves and failed for the same underlying reason: when the act of charging shifts the signal across its decision boundary, the gate flips and the system oscillates. Thanks to @harrymayr for the [pointed critique on #1371](https://github.com/Zendure/Zendure-HA/pull/1371#issuecomment-4447729750) about `p1` being a residual rather than a measure of surplus, and the [`homeInput > 0 AND batteryInput > 0` charge classification](https://github.com/Zendure/Zendure-HA/pull/1374) in #1374 — that's the direction this PR follows, just as a quantitative cap (`min(homeInput, batteryInput)`) on the existing subtraction rather than a binary toggle in the classifier, so it composes with the current pipeline rather than rewriting it.

## Scope

- Touches only the charge branch of the classifier in `powerChanged`. Per-device contribution stays in the same loop; just the value being subtracted is bounded.
- Independent of #1352 (deadband) and #1368 (offgrid-as-discharge); composes cleanly with both.
- No new sensors, no new constants, no behavior change in MATCHING_CHARGE / STORE_SOLAR / MANUAL modes (they consume the same `setpoint`).

## Test plan

- [x] Scenario A (SF 2400 AC + 2× Hyper 2000): residual ~70 W grid import eliminated, Hyper output rises from 409 → ~477 W.
- [x] Scenario B (SF 800 Pro + 2× ACE 1500): ACEs stop being commanded to charge from grid; system converges to balanced.
- [x] PV-coupled steady-state absorption preserved (full credit when `homeInput == batteryInput`).
- [x] No oscillation during the idle → engaged → steady-state transition: the credit follows `batteryInput` continuously instead of flipping on a threshold crossing.
- [ ] Long-term run to confirm no regression in MATCHING_CHARGE / STORE_SOLAR / MANUAL modes (they reuse the same pre-dispatch setpoint).