### PR TITLE
fix(device): register battery entities immediately on first packData

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -323,9 +323,15 @@ class ZendureDevice(EntityDevice):
                     continue
 
                 if (bat := self.batteries.get(sn, None)) is None:
-                    self.batteries[sn] = ZendureBattery(self.hass, sn, self)
+                    bat = ZendureBattery(self.hass, sn, self)
+                    self.batteries[sn] = bat
 
-                elif bat and b:
+                # Always apply properties — including for newly created batteries.
+                # With elif, a new battery received no entityUpdate on its first packData
+                # message, so HA entities were never created until the *next* poll cycle
+                # (every 60 s).  This caused batteries to be invisible after a failed
+                # initial httpGet (e.g. brief WiFi outage at startup).
+                if bat and b:
                     for key, value in b.items():
                         if key != "sn":
                             bat.entityUpdate(key, value)


### PR DESCRIPTION
As suggested here: https://github.com/Zendure/Zendure-HA/pull/1362#issuecomment-4522145057

An elif-branch caused newly created ZendureBattery instances to skip entityUpdate on their first packData message — entities were not visible in HA until the next poll cycle (up to 60 s later). Most noticeable after a brief WiFi outage at startup when the initial httpGet failed.
