### PR TITLE
HUB/AIO: Add device minimum discharge power

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -140,6 +140,7 @@ class ZendureDevice(EntityDevice):
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
         self.exports_bypass: bool = True
+        self.awake: bool = False
 
         self.create_entities()
 
@@ -286,6 +287,22 @@ class ZendureDevice(EntityDevice):
 
         soc = self.minSoc.asNumber
         return 0 if level <= soc else min(999, self.kWh * 10 / power * (level - soc))
+
+    @property
+    def min_output(self) -> int:
+        # Minimum discharge power to keep the microinverter engaged; only HUB/AIO expose it.
+        entity = getattr(self, "minOutputPower", None)
+        return entity.asInt if entity is not None else 0
+
+    def on_direction_change(self, charging: bool) -> None:
+        # Awake while discharging so power_discharge can hold the microinverter above its minimum.
+        self.awake = not charging
+
+    def localEntityWrite(self, entity: EntityZendure, value: Any) -> None:
+        # Snap values below 101 to the nearest step in {0, 30, 60, 90, 100}.
+        if entity.propertyName == "min_output_power" and isinstance(value, (int, float)) and value <= 100:
+            value = min([0, 30, 60, 90, 100], key=lambda x: abs(x - value))
+        entity.update_value(value)
 
     async def entityWrite(self, entity: EntityZendure, value: Any) -> None:
         if entity.translation_key is None:
@@ -655,6 +672,8 @@ class ZendureDevice(EntityDevice):
     async def power_discharge(self, power: int) -> int:
         """Set discharge power."""
         power = max(0, min(power, self.discharge_limit))
+        if self.awake and self.min_output > 0 and self.state not in (DeviceState.SOCEMPTY, DeviceState.SOCFULL) and self.electricLevel.asInt > self.minSoc.asNumber:
+            power = max(power, self.min_output)
         if abs(power - self.homeOutput.asInt + self.homeInput.asInt) <= SmartMode.POWER_TOLERANCE:
             _LOGGER.info("Power discharge %s => no action [power %s]", self.name, power)
             return self.homeOutput.asInt

--- a/custom_components/zendure_ha/devices/aio2400.py
+++ b/custom_components/zendure_ha/devices/aio2400.py
@@ -3,10 +3,12 @@
 import logging
 from typing import Any
 
+from homeassistant.components.number import NumberMode
 from homeassistant.core import HomeAssistant
 
 from custom_components.zendure_ha.const import SmartMode
 from custom_components.zendure_ha.device import ZendureLegacy
+from custom_components.zendure_ha.number import ZendureRestoreNumber
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,6 +20,7 @@ class AIO2400(ZendureLegacy):
         """AIO 2400 cannot charge using AC"""
         self.setLimits(0, 1200)
         self.maxSolar = -1200
+        self.minOutputPower = ZendureRestoreNumber(self, "min_output_power", self.localEntityWrite, None, "W", "power", 800, 0, NumberMode.SLIDER)
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("No AC charge for %s available", self.name)

--- a/custom_components/zendure_ha/devices/hub1200.py
+++ b/custom_components/zendure_ha/devices/hub1200.py
@@ -3,9 +3,11 @@
 import logging
 from typing import Any
 
+from homeassistant.components.number import NumberMode
 from homeassistant.core import HomeAssistant
 
 from custom_components.zendure_ha.device import ZendureBattery, ZendureLegacy
+from custom_components.zendure_ha.number import ZendureRestoreNumber
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,6 +18,7 @@ class Hub1200(ZendureLegacy):
         super().__init__(hass, deviceId, prodName, definition["productModel"], definition)
         self.setLimits(0, 1200)
         self.maxSolar = -800
+        self.minOutputPower = ZendureRestoreNumber(self, "min_output_power", self.localEntityWrite, None, "W", "power", 800, 0, NumberMode.SLIDER)
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("AC Power charge %s not available => set power from %s to 0", self.name, power)

--- a/custom_components/zendure_ha/devices/hub2000.py
+++ b/custom_components/zendure_ha/devices/hub2000.py
@@ -3,9 +3,11 @@
 import logging
 from typing import Any
 
+from homeassistant.components.number import NumberMode
 from homeassistant.core import HomeAssistant
 
 from custom_components.zendure_ha.device import ZendureBattery, ZendureLegacy
+from custom_components.zendure_ha.number import ZendureRestoreNumber
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +21,7 @@ class Hub2000(ZendureLegacy):
         """power to micro inverter up to 1200W"""
         self.setLimits(0, 1200)
         self.maxSolar = -2400
+        self.minOutputPower = ZendureRestoreNumber(self, "min_output_power", self.localEntityWrite, None, "W", "power", 800, 0, NumberMode.SLIDER)
 
     async def charge(self, power: int) -> int:
         _LOGGER.info("AC Power charge %s not available => set power from %s to 0", self.name, power)

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -266,6 +266,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     if len(self.devices) > 0:
                         for d in self.devices:
                             await d.power_off()
+                            d.awake = False
 
     async def _async_update_data(self) -> None:
 
@@ -458,6 +459,13 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     self.discharge_weight += d.pwr_max * d.electricLevel.asInt
                     setpoint += home
 
+                elif d.min_output > 0 and d.state not in (DeviceState.SOCEMPTY, DeviceState.SOCFULL):
+                    # Idle but has a minimum discharge configured. Classify as discharge.
+                    self.discharge.append(d)
+                    self.discharge_limit += d.fuseGrp.discharge_limit(d)
+                    self.discharge_optimal += d.discharge_optimal
+                    self.discharge_produced -= d.pwr_produced
+                    self.discharge_weight += d.pwr_max * d.electricLevel.asInt
                 else:
                     self.idle.append(d)
                     self.idle_lvlmax = max(self.idle_lvlmax, d.electricLevel.asInt)
@@ -512,6 +520,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             case ManagerMode.OFF:
                 self.operationstate.update_value(ManagerState.OFF.value)
 
+    def _set_direction(self, charging: bool) -> None:
+        _LOGGER.info("Power direction => %s", "charge" if charging else "discharge")
+        for d in self.devices:
+            d.on_direction_change(charging)
+
     async def power_charge(self, setpoint: int, time: datetime) -> None:
         """Charge devices."""
         _LOGGER.info("Charge => setpoint %sW", setpoint)
@@ -530,6 +543,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 self.charge_time = time + timedelta(seconds=2 if (time - self.charge_last).total_seconds() > 300 else 60)
                 self.charge_last = self.charge_time
                 self.pwr_low = 0
+                self._set_direction(True)
             setpoint = 0
         self.operationstate.update_value(ManagerState.CHARGE.value if setpoint < 0 else ManagerState.IDLE.value)
 
@@ -587,6 +601,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         if self.charge_time != datetime.max:
             self.charge_time = datetime.max
             self.pwr_low = 0
+            self._set_direction(False)
 
         # stop charging devices
         for d in self.charge:

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -101,6 +101,9 @@
       },
       "soc_set": {
         "name": "SoC-Zielwert"
+      },
+      "min_output_power": {
+        "name": "Mindestentladung"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -112,6 +112,9 @@
       },
       "soc_set": {
         "name": "Target SoC"
+      },
+      "min_output_power": {
+        "name": "Min Discharge"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -102,6 +102,9 @@
       },
       "soc_set": {
         "name": "SOC maximum"
+      },
+      "min_output_power": {
+        "name": "Décharge minimale"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -98,6 +98,9 @@
       },
       "soc_set": {
         "name": "SOC Maximaal"
+      },
+      "min_output_power": {
+        "name": "Minimale ontlading"
       }
     },
     "sensor": {

--- a/custom_components/zendure_ha/translations/pl.json
+++ b/custom_components/zendure_ha/translations/pl.json
@@ -109,7 +109,7 @@
       "soc_set": {
         "name": "Docelowe SoC"
       },
-      "min_battery_output_power": {
+      "min_output_power": {
         "name": "Minimalne rozładowanie"
       }
     },


### PR DESCRIPTION
## Description

This PR introduces a configurable **Min Discharge** slider for each device to prevent inverter MPPT cooldowns and ensure instant responsiveness. 

### Why this is needed
Previously, the inverter could build up to ~15 minutes delay by:
* the microinverter's grid-reconnect (~5 min)
* auto-restart (~10 min) timers 
after it goes idle (documented in the Hub 2000 manual).
By allowing users to enforce a minimum baseline output power, the inverter stays continuously active and ready to perform.

### Key Changes
* **Min Discharge Slider**: Added a slider ranging from `0–800W`.
* **Finer Low-Power Control**: Configured dynamic steps of `30W` when the value is below `100W`.
* **Floor Enforcement**: The manager now strictly enforces this minimum limit during both active discharge and idle device startup phases.
* **Mode Exclusions**: The minimum output floor is automatically bypassed in the following modes:
  * `STORE_SOLAR`: Prioritizes full power transfer directly to the batteries.
  * `MANUAL`: Defers entirely to user-defined manual output control.

---

## Behavior Example


| Current Power P1 | Min Output Setting | Expected Final Output |
| :--- | :--- | :--- |
| 0W | 100W | **100W** |
| 200W | 100W | **200W** |
| -300W | 100W | **-300W** |

---

## How to Test
1. Open the device settings (eg HUB2000) and verify the new **Min Discharge** slider works (0-800W).
2. Verify that values below 100W change in steps of 30W.
3. Set the slider to 100W, trigger an idle startup, and ensure the power output does not drop below 100W.
4. Switch to `STORE_SOLAR` or `MANUAL` mode and confirm the minimum limit is ignored.
