### PR TITLE
New manager mode (Solar Pass-through) to smart pass-through all power to house 

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -491,8 +491,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     await self.power_discharge(setpoint)
 
             case ManagerMode.MATCHING_DISCHARGE:
-                # Only discharge, do nothing if setpoint is negative
-                await self.power_discharge(max(0, setpoint))
+                # Discharge to cover demand and always pass through available solar; never charge
+                await self.power_discharge(max(self.produced, setpoint))
 
             case ManagerMode.MATCHING_CHARGE | ManagerMode.STORE_SOLAR:
                 # Allow discharge of produced power in MATCHING_CHARGE-Mode, otherwise only charge


### PR DESCRIPTION
## Description

Adds a new smart mode: **Solar Pass-through** (`smart_solar_passthrough`), designed for situations where selling excess PV energy to the grid is profitable.

In this mode, all PV production is passed directly to the house and grid — the battery is only used to cover any remaining P1 grid import demand

  | PV | P1 (demand) | Battery output| Grid (export) |
  |-----|-------------|---------|---------------|
  | 300W | 100W | 0W | −200W |
  | 100W | 100W | 0W | 0W |
  | 100W | 200W | 100W | 0W |
  | 500W | 100W | 0W | −400W |

  **Useful when:**
  - Energy export prices are high and uers want to maximize grid export from PV
  - Users want the battery to act only as a P1 safety net, not a grid feed device




