### PR TITLE
fix(manager): keep AC relay in input mode when smart_charging has no surplus

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -486,9 +486,6 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 # d.pwr_produced is negative, but self.produced is positive
                 if setpoint > 0 and self.produced > SmartMode.POWER_START and self.operation == ManagerMode.MATCHING_CHARGE:
                     await self.power_discharge(min(self.produced, setpoint))
-                # send device into idle-mode
-                elif setpoint > 0:
-                    await self.power_discharge(0)
                 else:
                     await self.power_charge(min(0, setpoint), time)
 


### PR DESCRIPTION
### Bug (#1349)
In smart_charging / store_solar, a positive setpoint without PV surplus was routed to `power_discharge(0)`. For zenSDK AC devices `discharge()` always writes `acMode:2` — even for 0W — so every positive P1 fluctuation flipped the AC relay to output while the device was only supposed to charge, cutting an ongoing trickle charge and wearing the relay (also contributes to the excessive mode switching reported in #554).

### Fix
Route the no-surplus case through `power_charge(min(0, setpoint))`, the path already taken when `setpoint == 0`: devices go idle with `acMode:1` and the relay stays in AC-input mode (verified for every device family: zenSDK, Hyper, Hub, ACE — `charge(0)` puts each of them into idle). Passing through produced solar power is unchanged. Side benefit: the charge hysteresis is no longer re-armed on every surplus dip, so charging resumes immediately when the surplus returns.