### PR TITLE
Update output limit translation in German

### DIFF
--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -87,7 +87,7 @@
         "name": "AC-Eingangsgrenze"
       },
       "output_limit": {
-        "name": "Ausgangsleistung"
+        "name": "AC-Ausgangsgrenze"
       },
       "manual_power": {
         "name": "Manuelle Leistung"


### PR DESCRIPTION
The value beforehand was misleading.

If your battery is empty, it was indicating that the battery currently outputs energy to your home, but the value only shows a limit for the maximum of the AC output for my understanding.

<img width="505" height="1434" alt="image" src="https://github.com/user-attachments/assets/356179ed-85a7-4010-ba64-2ba822974829" />
 