### PR TITLE
Fix charge-side kickstart walk for ZenSdk devices

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -749,10 +749,9 @@ class ZendureZenSdk(ZendureDevice):
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
         _LOGGER.info("Power charge %s => %s", self.name, power)
-        # inputLimit is always reported as a positive magnitude (range 0..abs(charge)),
-        # so walk the charge floor up using the same sign convention as discharge below.
         if power == -SmartMode.POWER_START and self.limitInput.asInt >= SmartMode.POWER_START and self.homeInput.asInt == 0:
             power = -min(self.limitInput.asInt + 4, 2 * SmartMode.POWER_START)
+            _LOGGER.info("Power charge kickstart %s => %s", self.name, power)
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 
@@ -760,6 +759,7 @@ class ZendureZenSdk(ZendureDevice):
         _LOGGER.info("Power discharge %s => %s", self.name, power)
         if power == SmartMode.POWER_START and self.limitOutput.asInt >= SmartMode.POWER_START and self.homeOutput.asInt == 0:
             power = min(self.limitOutput.asInt + 4, 2 * SmartMode.POWER_START)
+            _LOGGER.info("Power discharge kickstart %s => %s", self.name, power)
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
         return power
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -749,8 +749,10 @@ class ZendureZenSdk(ZendureDevice):
     async def charge(self, power: int, _off: bool = False) -> int:
         """Set charge power."""
         _LOGGER.info("Power charge %s => %s", self.name, power)
-        if power == -SmartMode.POWER_START and self.limitInput.asInt <= -SmartMode.POWER_START and self.homeInput.asInt == 0:
-            power = max(self.limitInput.asInt - 4, -2 * SmartMode.POWER_START)
+        # inputLimit is always reported as a positive magnitude (range 0..abs(charge)),
+        # so walk the charge floor up using the same sign convention as discharge below.
+        if power == -SmartMode.POWER_START and self.limitInput.asInt >= SmartMode.POWER_START and self.homeInput.asInt == 0:
+            power = -min(self.limitInput.asInt + 4, 2 * SmartMode.POWER_START)
         await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
         return power
 


### PR DESCRIPTION
## Problem

SolarFlow AC devices (e.g. SF2400 AC/AC+) stay stuck and never start charging despite a clear solar surplus. The manager kickstart fires correctly (`Charge => setpoint -772W` followed by `Power charge … => -50` every cycle), but `charge()` stays pinned at the `-POWER_START` floor: `gridInputPower` remains 0 and the surplus is exported. Observed for ~15 min until a watchdog/power-cycle.

## Root cause

In `ZendureZenSdk.charge()` the kickstart "walk" that should ramp the input limit up was guarded by:

```python
if power == -SmartMode.POWER_START and self.limitInput.asInt <= -SmartMode.POWER_START and self.homeInput.asInt == 0:
    power = max(self.limitInput.asInt - 4, -2 * SmartMode.POWER_START)
```

`limitInput` (`inputLimit`) is created with `update_range(0, abs(charge))`, so its value is **always a positive magnitude** (`0..2400`). The condition `limitInput.asInt <= -POWER_START` can therefore never be true — the block is always skipped, the command stays at the flat `-POWER_START` floor, and the inverter never ramps up. This affects all ZenSdk devices, not a single unit, which is why the kickstart helps discharge stalls (correct sign convention) but never charge stalls.

## Fix

Mirror the discharge branch sign convention so the input limit walks up until the inverter starts drawing power, after which `homeInput > 0` ends the walk and normal distribution takes over:

```python
if power == -SmartMode.POWER_START and self.limitInput.asInt >= SmartMode.POWER_START and self.homeInput.asInt == 0:
    power = -min(self.limitInput.asInt + 4, 2 * SmartMode.POWER_START)
```

Walk: `50 -> 54 -> 58 … -> 100`, command `inputLimit: 54/58/…/100`.

## Notes

- The cases where an already-wedged inverter only recovers after a physical power-cycle are firmware-level and out of scope here; this change prevents reaching that state in the common case by actually ramping instead of hammering the `-50` floor.

Refs Zendure/Zendure-HA#1230