### PR TITLE
Avoid blocking file read when checking entities

### DIFF
--- a/custom_components/zendure_ha/__init__.py
+++ b/custom_components/zendure_ha/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import device_registry as dr
 from .api import Api
 from .const import CONF_MQTTLOG, CONF_P1METER, CONF_SIM
 from .device import ZendureDevice
+from .entity import EntityDevice
 from .manager import ZendureConfigEntry, ZendureManager
 from .migration import Migration
 
@@ -29,6 +30,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ZendureConfigEntry) ->
 async def async_setup_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> bool:
     """Set up Zendure as config entry."""
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await EntityDevice.async_load_translations(hass)
     manager = ZendureManager(hass, entry)
     await manager.loadDevices()
     entry.runtime_data = manager

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import unicodedata
+from pathlib import Path
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -180,6 +182,18 @@ class EntityDevice:
 
     empty = EntityZendure(None, "empty")
 
+    @classmethod
+    async def async_load_translations(cls, hass: HomeAssistant) -> None:
+        """Load the translation_key -> domain map from disk, off the event loop."""
+        if cls.checkEntity:
+            return
+
+        def _load() -> dict[str, str]:
+            _t = json.loads((Path(__file__).parent / "translations" / "en.json").read_text())
+            return {key: domain for domain, keys in _t.get("entity", {}).items() for key in keys}
+
+        cls.checkEntity = await hass.async_add_executor_job(_load)
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -224,12 +238,8 @@ class EntityDevice:
         entity_registry = er.async_get(self.hass)
         ed: dict[str, list[er.RegistryEntry]] = {}
         for entity in er.async_entries_for_device(entity_registry, di.id, True):
-            if entity.platform != DOMAIN or entity.translation_key is None:
-                continue
-            dn = self.checkEntity.get(entity.translation_key)
-            if dn is not None and dn != entity.domain:
-                continue
-            ed.setdefault(entity.translation_key, []).append(entity)
+            if entity.platform == DOMAIN and (dn := self.checkEntity.get(entity.translation_key)) is not None and dn == entity.domain:
+                ed.setdefault(entity.translation_key, []).append(entity)
 
         # check al entities
         for key, entries in ed.items():

--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import unicodedata
-from pathlib import Path
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -64,8 +62,8 @@ class EntityZendure(Entity):
         self.internal_integration_suggested_object_id = self._attr_unique_id
         self._attr_translation_key = snakecase(uniqueid)
         device.entities[uniqueid] = self
-        if domain and device.checkEntity is not None and self._attr_translation_key not in device.checkEntity:
-            device.checkEntity[self._attr_translation_key] = domain
+        if domain:
+            device.checkEntity.setdefault(self._attr_translation_key, domain)
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -178,7 +176,7 @@ class EntityDevice:
         "ts": ("none"),
         "tsZone": ("none"),
     }
-    checkEntity: dict[str, str] | None = None
+    checkEntity: dict[str, str] = {}
 
     empty = EntityZendure(None, "empty")
 
@@ -222,16 +220,16 @@ class EntityDevice:
             self.attr_device_info["via_device"] = (DOMAIN, parent)
 
     def check_entities(self, di: DeviceEntry, name: str) -> None:
-        if EntityDevice.checkEntity is None:
-            _t = json.loads((Path(__file__).parent / "translations" / "en.json").read_text())
-            EntityDevice.checkEntity = {key: domain for domain, keys in _t.get("entity", {}).items() for key in keys}
-
         # Get all entities for this device and group them by translation_key if they match the current device and platform
         entity_registry = er.async_get(self.hass)
         ed: dict[str, list[er.RegistryEntry]] = {}
         for entity in er.async_entries_for_device(entity_registry, di.id, True):
-            if entity.platform == DOMAIN and (dn := self.checkEntity.get(entity.translation_key)) is not None and dn == entity.domain:
-                ed.setdefault(entity.translation_key, []).append(entity)
+            if entity.platform != DOMAIN or entity.translation_key is None:
+                continue
+            dn = self.checkEntity.get(entity.translation_key)
+            if dn is not None and dn != entity.domain:
+                continue
+            ed.setdefault(entity.translation_key, []).append(entity)
 
         # check al entities
         for key, entries in ed.items():


### PR DESCRIPTION
## Problem

`EntityDevice.check_entities()` runs during integration setup (a sync method on the event loop) and lazily builds its `translation_key -> domain` map by reading `translations/en.json` from disk. That `read_text()` is blocking I/O inside the event loop and triggers Home Assistant's "Detected blocking call to open/read inside the event loop" warning at startup.

## Fix

Build the map incrementally instead of reading the file. Every entity already knows its own domain, so it records `translation_key -> domain` via `setdefault` when it is created. `checkEntity` becomes a plain class-level dict, the `json`/`pathlib` imports are dropped, and `check_entities()` no longer touches the filesystem.

The registry cleanup keeps working: the canonical `entity_id` is derived from each registry entry's own domain, not from the map — the map is only used to filter out cross-domain mismatches. The filter is relaxed accordingly so entries whose key isn't (yet) in the map are still considered.

This is the `entity.py` portion only of the original fix by @zaubara; the unrelated `POWER_START` change is left out as it is already in `master`.
