### PR TITLE
Modify German translations for pass_mode and grid_reverse

### DIFF
--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -416,7 +416,7 @@
         }
       },
       "pass_mode": {
-        "name": "Bypass-Modus",
+        "name": "Energie Export old", #only at HUB1200/200 and AIO2400
         "state": {
           "auto": "Automatisch",
           "off": "Immer aus",
@@ -432,11 +432,11 @@
         }
       },
       "grid_reverse": {
-        "name": "Energie Export",
+        "name": "Energie Export", #until all models from Hyper2000 or newer gen
         "state": {
-          "disabled": "Deaktiviert",
-          "allow": "Erlaubt",
-          "forbidden": "Verboten"
+          "auto": "Automatisch",
+          "off": "Immer aus",
+          "on": "Immer an"
         }
       },
       "fan_speed": {

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -416,7 +416,7 @@
         }
       },
       "pass_mode": {
-        "name": "Energie Export old", #only at HUB1200/200 and AIO2400
+        "name": "Energie Export old",
         "state": {
           "auto": "Automatisch",
           "off": "Immer aus",
@@ -432,7 +432,7 @@
         }
       },
       "grid_reverse": {
-        "name": "Energie Export", #until all models from Hyper2000 or newer gen
+        "name": "Energie Export",
         "state": {
           "auto": "Automatisch",
           "off": "Immer aus",

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -419,8 +419,8 @@
         "name": "Energie Export old",
         "state": {
           "auto": "Automatisch",
-          "off": "Immer aus",
-          "on": "Immer an"
+          "forbidden": "Verboten",
+          "allow": "Erlaubt"
         }
       },
       "grid_off_mode": {
@@ -435,8 +435,8 @@
         "name": "Energie Export",
         "state": {
           "auto": "Automatisch",
-          "off": "Immer aus",
-          "on": "Immer an"
+          "forbidden": "Verboten",
+          "allow": "Erlaubt"
         }
       },
       "fan_speed": {


### PR DESCRIPTION
Updated German translations for pass_mode and grid_reverse names.

When it is right, for all other translations is also needed to do.

It seems that "pass_mode" is the old version of "grid reverse" but with same states.