### PR TITLE
Documentation added to reamde.md and extract some constants that control the power distribution , bug fix for charge_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ This Home Assistant integration connects your Zendure devices to Home Assistant,
 - **Configuration:**
   - [Fuse Group](https://github.com/Zendure/Zendure-HA/wiki/Fuse-Group)
   - Zendure Manager
-    - [Power distribution strategy](https://github.com/Zendure/Zendure-HA/wiki/Power-distribution-strategy)
+    - **Outdated:** [Power distribution strategy](https://github.com/Zendure/Zendure-HA/wiki/Power-distribution-strategy)
   - [Local Mqtt (Legacy devices)](https://github.com/Zendure/Zendure-HA/wiki/Local-Mqtt-(Legacy-Devices))
   - Home Assistant Energy Dashboard
+
+- **How it works:**
+  - surfer1264 - [Power Distribution explained - simple case](https://github.com/surfer1264/Zendure-Stuff/wiki/Standard‐Betrieb-zweier-gleicher-Hubs)
+  - surfer1264 - [Power Distribution explained - complexcase](https://github.com/surfer1264/Zendure-Stuff/wiki/Lastverteilung-z‐HA-ein-komplexes-Beispiel)
+  - surfer1264 - [connection status explained - HEMS](https://github.com/surfer1264/Zendure-Stuff/wiki/Zendure-HEMS-und-zHA)
 
 - **Supported devices:**
   - Ace1500

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ This Home Assistant integration connects your Zendure devices to Home Assistant,
   - Home Assistant Energy Dashboard
 
 - **How it works:**
-  - surfer1264 - [Power Distribution explained - simple case](https://github.com/surfer1264/Zendure-Stuff/wiki/Standard‐Betrieb-zweier-gleicher-Hubs)
-  - surfer1264 - [Power Distribution explained - complexcase](https://github.com/surfer1264/Zendure-Stuff/wiki/Lastverteilung-z‐HA-ein-komplexes-Beispiel)
-  - surfer1264 - [connection status explained - HEMS](https://github.com/surfer1264/Zendure-Stuff/wiki/Zendure-HEMS-und-zHA)
+  - surfer1264 - [Power Distribution explained - simple case](https://github.com/surfer1264/Zendure-Stuff/wiki/Standard‐Betrieb-zweier-gleicher-Hubs) :de:
+  - surfer1264 - [Power Distribution explained - complexcase](https://github.com/surfer1264/Zendure-Stuff/wiki/Lastverteilung-z‐HA-ein-komplexes-Beispiel) :de:
+  - surfer1264 - [connection status explained - HEMS](https://github.com/surfer1264/Zendure-Stuff/wiki/Zendure-HEMS-und-zHA) :de:
 
 - **Supported devices:**
   - Ace1500
   - Aio2400
   - Hyper2000
-  - Hub1200 [German](https://github.com/Zendure/Zendure-HA/wiki/SolarFlow-Hub1200-German)
+  - Hub1200 [German](https://github.com/surfer1264/Zendure-Stuff/wiki/SF1200_Entity_der_Zendure_HA_Integration) :de:
   - Hub2000
   - [SF800](https://github.com/Zendure/Zendure-HA/wiki/SolarFlow-800)
   - SF800 Pro

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -74,7 +74,10 @@ class SmartMode:
 
     # DIVISOR used in manager.py and device.py 
     # make sure we have devices in optimal working range start or stop a second device for charge or dischage
-    DISCHARGE_OPTIMAL_DIVISOR = 2.8    # Divisor for discharge_optimal (default 4)
-    DISCHARGE_START_DIVISOR = 8        # Divisor for discharge_start  (default 10)
+    DISCHARGE_OPTIMAL_DIVISOR = 4      # Divisor for discharge_optimal (default 4)
+    DISCHARGE_START_DIVISOR = 10       # Divisor for discharge_start  (default 10)
     CHARGE_OPTIMAL_DIVISOR = 4         # Divisor for charge_optimal (default 4)
     CHARGE_START_DIVISOR = 10          # Divisor for charge_start  (default 10)
+    # %-Punkte SoC-Differenz, ab der ein Idle-Gerät bevorzugt dem aktiven Gerät mit ungünstigerem SoC vorgezogen wird
+    SOC_BALANCE_MARGIN = 3  # %-Punkte SoC-Differenz, ab der ein Idle-Gerät bevorzugt (devault 3)
+

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -71,3 +71,10 @@ class SmartMode:
 
     POWER_START = 50  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
+
+    # DIVISOR used in manager.py and device.py 
+    # make sure we have devices in optimal working range start or stop a second device for charge or dischage
+    DISCHARGE_OPTIMAL_DIVISOR = 2.8    # Divisor for discharge_optimal (default 4)
+    DISCHARGE_START_DIVISOR = 8        # Divisor for discharge_start  (default 10)
+    CHARGE_OPTIMAL_DIVISOR = 4         # Divisor for charge_optimal (default 4)
+    CHARGE_START_DIVISOR = 10          # Divisor for charge_start  (default 10)

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -188,14 +188,14 @@ class ZendureDevice(EntityDevice):
         """Set the device limits."""
         try:
             self.charge_limit = charge
-            self.charge_optimal = charge // 4
-            self.charge_start = charge // 10
+            self.charge_optimal = int(charge // SmartMode.CHARGE_OPTIMAL_DIVISOR)
+            self.charge_start = int(charge // SmartMode.CHARGE_START_DIVISOR)
             self.limitInput.update_range(0, abs(charge))
 
             self.discharge_limit = discharge
-            self.discharge_optimal = discharge // 4
-            self.discharge_start = discharge // 10
-            self.limitOutput.update_range(0, discharge)
+            self.discharge_optimal = int(discharge // SmartMode.DISCHARGE_OPTIMAL_DIVISOR)
+            self.discharge_start = int(discharge // SmartMode.DISCHARGE_START_DIVISOR)
+            self.limitOutput.update_range(0, discharge)            
         except Exception:
             _LOGGER.error("SetLimits error %s %s %s!", self.name, charge, discharge)
 

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -563,7 +563,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 pwr = 0 if self.pwr_low > abs(d.charge_optimal) else pwr
 
             setpoint -= await d.power_charge(pwr)
-            dev_start += -1 if pwr != 0 and d.electricLevel.asInt > self.idle_lvlmin + 3 else 0
+            dev_start += -1 if pwr != 0 and d.electricLevel.asInt > self.idle_lvlmin + SmartMode.SOC_BALANCE_MARGIN else 0
 
         # start idle device if needed
         if dev_start < 0 and len(self.idle) > 0:
@@ -632,7 +632,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 self.pwr_low = 0 if (delta := dstart * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
                 pwr = 0 if self.pwr_low > doptimal else pwr
             setpoint -= await d.power_discharge(pwr)
-            dev_start += 1 if pwr != 0 and d.electricLevel.asInt + 3 < self.idle_lvlmax else 0
+            dev_start += 1 if pwr != 0 and d.electricLevel.asInt + SmartMode.SOC_BALANCE_MARGIN < self.idle_lvlmax else 0
 
         # start idle device if needed
         if dev_start > 0 and len(self.idle) > 0:

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -623,9 +623,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
             # make sure we have devices in optimal working range
             if len(self.discharge) > 1 and i == 0 and d.state != DeviceState.SOCFULL:
-                self.pwr_low = 0 if (delta := d.discharge_start * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
-                pwr = 0 if self.pwr_low > d.discharge_optimal else pwr
-
+                # cautious fuse-group cap: thresholds never exceed what pwr_max (the active
+                # fuse-group limit) would imply; unchanged when pwr_max == hardware limit
+                dstart = min(d.discharge_start, d.pwr_max // SmartMode.DISCHARGE_START_DIVISOR) if d.pwr_max > 0 else d.discharge_start
+                doptimal = min(d.discharge_optimal, int(d.pwr_max // SmartMode.DISCHARGE_OPTIMAL_DIVISOR)) if d.pwr_max > 0 else d.discharge_optimal
+                self.pwr_low = 0 if (delta := dstart * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
+                pwr = 0 if self.pwr_low > doptimal else pwr
             setpoint -= await d.power_discharge(pwr)
             dev_start += 1 if pwr != 0 and d.electricLevel.asInt + 3 < self.idle_lvlmax else 0
 

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -126,8 +126,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
                 # create the device and mqtt server
                 device = init(self.hass, deviceId, dev.get("deviceName", prodModel), dev)
-                device.discharge_start = device.discharge_limit // 10
-                device.discharge_optimal = device.discharge_limit // 4
+                device.discharge_start = device.discharge_limit // SmartMode.DISCHARGE_START_DIVISOR
+                device.discharge_optimal = device.discharge_limit // SmartMode.DISCHARGE_OPTIMAL_DIVISOR
                 Api.devices[deviceId] = device
 
                 # Check if we should automatically manage MQTT users (opt-in)

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -128,6 +128,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 device = init(self.hass, deviceId, dev.get("deviceName", prodModel), dev)
                 device.discharge_start = device.discharge_limit // SmartMode.DISCHARGE_START_DIVISOR
                 device.discharge_optimal = device.discharge_limit // SmartMode.DISCHARGE_OPTIMAL_DIVISOR
+                device.charge_start = device.charge_limit // SmartMode.CHARGE_START_DIVISOR      # NEU
+                device.charge_optimal = device.charge_limit // SmartMode.CHARGE_OPTIMAL_DIVISOR  # NEU
                 Api.devices[deviceId] = device
 
                 # Check if we should automatically manage MQTT users (opt-in)
@@ -558,7 +560,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             # make sure we have devices in optimal working range
             if len(self.charge) > 1 and i == 0:
                 self.pwr_low = 0 if (delta := d.charge_start * 1.5 - pwr) >= 0 else self.pwr_low + int(-delta)
-                pwr = 0 if self.pwr_low < d.charge_optimal else pwr
+                pwr = 0 if self.pwr_low > abs(d.charge_optimal) else pwr
 
             setpoint -= await d.power_charge(pwr)
             dev_start += -1 if pwr != 0 and d.electricLevel.asInt > self.idle_lvlmin + 3 else 0


### PR DESCRIPTION
1)Added some documentation-links in Readme.md 
Explaining the Power Distribution in z-HA with a simple and with a complex sample

2)Bug fix: power distribution in case of three charging devices does not work. The stop device couldn't be reached when charging power was under the threshold (charge_start x 1.5) ...because of a sign problem..pwr_low doesn't work in this case.

3)Using and defining constants in constants.py for 
Charge_optimal
Discharge_optimal
Charge_start
Discharge_start
Soc_balance_margin (the 3% Limit) 

As configurable parameters and the ability to adjust the power distribution thresholds (for Charge and discharge) in a more easy way in Const.py for experienced users