### PR TITLE
Specific config-flow error messages for setup failures

### DIFF
--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import binascii
 import hashlib
 import json
 import logging
@@ -13,7 +14,6 @@ from datetime import datetime
 from typing import Any, Mapping
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from paho.mqtt import client as mqtt_client
@@ -39,7 +39,11 @@ from .devices.hub2000 import Hub2000
 from .devices.hyper2000 import Hyper2000
 from .devices.solarflow800 import SolarFlow800, SolarFlow800Plus, SolarFlow800Pro
 from .devices.solarflow1600 import SolarFlow1600
-from .devices.solarflow2400 import SolarFlow2400AC, SolarFlow2400AC_Plus, SolarFlow2400Pro
+from .devices.solarflow2400 import (
+    SolarFlow2400AC,
+    SolarFlow2400AC_Plus,
+    SolarFlow2400Pro,
+)
 from .devices.solarflow4000 import SolarFlow4000AC_Plus
 from .devices.superbasev4600 import SuperBaseV4600
 from .devices.superbasev6400 import SuperBaseV6400
@@ -48,6 +52,15 @@ _LOGGER = logging.getLogger(__name__)
 
 ZENDURE_MANAGER_STORAGE_VERSION = 1
 ZENDURE_DEVICES = "devices"
+
+
+class ApiError(Exception):
+    """A Zendure API/setup failure with a translation key for the config flow."""
+
+    def __init__(self, key: str, detail: str = "") -> None:
+        self.key = key
+        self.detail = detail
+        super().__init__(key)
 
 
 class Api:
@@ -115,9 +128,14 @@ class Api:
         """Connect to the Zendure API."""
         try:
             devices = await Api.ApiHA(hass, data)
-        except Exception:  # pylint: disable=broad-except
+        except ApiError:
+            # During a coordinator reload we must not surface the error; fall back to
+            # the last-known device list from storage. The config flow (reload=False)
+            # wants the specific ApiError so it can show a precise message.
+            if not reload:
+                raise
             _LOGGER.error("Failed to connect to Zendure API")
-            return None
+            devices = None
 
         # Open the storage
         if reload:
@@ -136,11 +154,14 @@ class Api:
     async def ApiHA(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any] | None:
         session = async_get_clientsession(hass)
 
-        if (token := data.get(CONF_APPTOKEN)) is not None and len(token) > 1:
+        if (token := data.get(CONF_APPTOKEN)) is None or len(token) <= 1:
+            raise ApiError("malformed_token")
+        try:
             base64_url = b64decode(str(token)).decode("utf-8")
             api_url, appKey = base64_url.rsplit(".", 1)
-        else:
-            raise ServiceValidationError(translation_domain=DOMAIN, translation_key="no_zendure_token")
+        except (binascii.Error, UnicodeDecodeError, ValueError) as err:
+            _LOGGER.error("Malformed Zendure token: %s", err)
+            raise ApiError("malformed_token") from err
 
         try:
             body = {
@@ -178,23 +199,27 @@ class Api:
 
             result = await session.post(url=f"{api_url}/api/ha/deviceList", json=body, headers=headers)
             data = await result.json()
-            if data.get("code") != 200:
-                _LOGGER.debug("Zendure API response: %s Message: %s", data.get("code"), data.get("msg"))
-            elif data.get("code") == 200 and len(data["data"]["deviceList"]) == 0:
-                _LOGGER.error("Zendure API does not reply any devices: %s", data)
-                return None
-            elif data.get("code") == 200 and len(data["data"]["mqtt"]) == 0:
-                _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
-                return None
-            if not data.get("success", False) or (result := data["data"]) is None:
-                _LOGGER.error("Zendure API returned failure or missing data: %s", data)
-                return None
-            return dict(result)
-
+        except ApiError:
+            raise
         except Exception as e:
-            _LOGGER.error("Unable to connect to Zendure %s!", e)
+            _LOGGER.error("Unable to reach Zendure API %s!", e)
             _LOGGER.error(traceback.format_exc())
-            return None
+            raise ApiError("cannot_connect", str(e)) from e
+
+        if data.get("code") != 200 or not data.get("success", False):
+            msg = str(data.get("msg", "")) or f"code {data.get('code')}"
+            _LOGGER.error("Zendure API rejected the request: %s", data)
+            raise ApiError("api_rejected", msg)
+        if (result := data.get("data")) is None:
+            _LOGGER.error("Zendure API returned no data: %s", data)
+            raise ApiError("api_rejected", "no data returned")
+        if len(result.get("deviceList", [])) == 0:
+            _LOGGER.error("Zendure API does not reply any devices: %s", data)
+            raise ApiError("no_devices")
+        if len(result.get("mqtt", {})) == 0:
+            _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
+            raise ApiError("no_mqtt")
+        return dict(result)
 
     def mqttInit(self, client: mqtt_client.Client, srv: str, port: str, user: str, psw: str) -> None:
         try:

--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 
-from .api import Api
+from .api import Api, ApiError
 from .const import (
     CONF_APPTOKEN,
     CONF_AUTO_MQTT_USER,
@@ -73,41 +73,48 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Step when user initializes a integration."""
         errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
         if user_input is not None:
             self._user_input = user_input
 
             try:
-                if await Api.Connect(self.hass, self._user_input, False) is None:
-                    errors["base"] = "invalid input"
-                else:
-                    localmqtt = user_input[CONF_MQTTLOCAL]
-                    if localmqtt:
-                        return await self.async_step_local()
-
-                    await self.async_set_unique_id("Zendure", raise_on_progress=False)
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(title="Zendure", data=self._user_input)
-
+                await Api.Connect(self.hass, self._user_input, False)
+            except ApiError as err:
+                errors["base"] = err.key
+                placeholders["detail"] = err.detail
             except Exception as err:  # pylint: disable=broad-except
-                errors["base"] = f"invalid input {err}"
+                _LOGGER.error("Unexpected exception: %s", err)
+                errors["base"] = "unknown"
+            else:
+                localmqtt = user_input[CONF_MQTTLOCAL]
+                if localmqtt:
+                    return await self.async_step_local()
 
-        return self.async_show_form(step_id="user", data_schema=self.data_schema, errors=errors)
+                await self.async_set_unique_id("Zendure", raise_on_progress=False)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title="Zendure", data=self._user_input)
+
+        return self.async_show_form(step_id="user", data_schema=self.data_schema, errors=errors, description_placeholders=placeholders)
 
     async def async_step_local(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
         if user_input is not None and user_input.get(CONF_MQTTSERVER, None) is not None:
             try:
                 self._user_input = self._user_input | user_input if self._user_input else user_input
-                if await Api.Connect(self.hass, self._user_input, False) is None:
-                    errors["base"] = "invalid input"
+                await Api.Connect(self.hass, self._user_input, False)
+            except ApiError as err:
+                errors["base"] = err.key
+                placeholders["detail"] = err.detail
             except Exception as err:  # pylint: disable=broad-except
-                errors["base"] = f"invalid input {err}"
+                _LOGGER.error("Unexpected exception: %s", err)
+                errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id("Zendure", raise_on_progress=False)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title="Zendure", data=self._user_input)
 
-        return self.async_show_form(step_id="local", data_schema=self.mqtt_schema, errors=errors)
+        return self.async_show_form(step_id="local", data_schema=self.mqtt_schema, errors=errors, description_placeholders=placeholders)
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Add reconfigure step to allow to reconfigure a config entry."""
@@ -115,6 +122,7 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
 
         entry = self._get_reconfigure_entry()
         schema = self.data_schema
+        placeholders: dict[str, str] = {}
         if user_input is not None:
             self._user_input = self._user_input | user_input
             use_mqtt = user_input.get(CONF_MQTTLOCAL, False)
@@ -122,11 +130,13 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
                 schema = self.mqtt_schema
             else:
                 try:
-                    if await Api.Connect(self.hass, self._user_input, False) is None:
-                        errors["base"] = "invalid input"
+                    await Api.Connect(self.hass, self._user_input, False)
+                except ApiError as err:
+                    errors["base"] = err.key
+                    placeholders["detail"] = err.detail
                 except Exception as err:  # pylint: disable=broad-except
                     _LOGGER.error("Unexpected exception: %s", err)
-                    errors["base"] = f"invalid input {err}"
+                    errors["base"] = "unknown"
                 else:
                     await self.async_set_unique_id("Zendure", raise_on_progress=False)
                     self._abort_if_unique_id_mismatch()
@@ -140,6 +150,7 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
                 suggested_values=entry.data | (user_input or {}),
             ),
             errors=errors,
+            description_placeholders=placeholders,
         )
 
     @staticmethod

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -5,7 +5,11 @@
       "reconfigure_successful": "Neukonfiguration erfolgreich"
     },
     "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen",
+      "cannot_connect": "Die Zendure-API ist nicht erreichbar. Prüfe deine Internetverbindung und versuche es erneut.",
+      "malformed_token": "Der Token ist ungültig. Kopiere den Home-Assistant-Token erneut aus der Zendure-App (Einstellungen, Entwickler).",
+      "api_rejected": "Zendure hat die Anfrage abgelehnt: {detail}",
+      "no_devices": "Token akzeptiert, aber es wurden keine Geräte für dieses Konto gefunden. Stelle sicher, dass du das Zendure-Konto verwendest, bei dem das Gerät registriert ist, sowie die richtige Region.",
+      "no_mqtt": "Token akzeptiert, aber es wurde kein MQTT-Server zurückgegeben. Aktiviere lokales oder Cloud-MQTT für dieses Konto in der Zendure-App.",
       "invalid_auth": "Ungültige Authentifizierung",
       "unknown": "Unerwarteter Fehler"
     },

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -5,7 +5,11 @@
       "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
+      "cannot_connect": "Could not reach the Zendure API. Check your internet connection and try again.",
+      "malformed_token": "The token is not valid. Copy the Home Assistant token again from the Zendure app (Settings, Developer).",
+      "api_rejected": "Zendure rejected the request: {detail}",
+      "no_devices": "Token accepted, but no devices were found on this account. Make sure you use the Zendure account the device is registered to, and the correct region.",
+      "no_mqtt": "Token accepted, but no MQTT server was returned. Enable local or cloud MQTT for this account in the Zendure app.",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error"
     },

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -5,7 +5,11 @@
       "reconfigure_successful": "Reconfiguration réussie"
     },
     "error": {
-      "cannot_connect": "Échec de la connexion",
+      "cannot_connect": "Impossible de joindre l'API Zendure. Vérifiez votre connexion Internet et réessayez.",
+      "malformed_token": "Le jeton n'est pas valide. Copiez à nouveau le jeton Home Assistant depuis l'application Zendure (Paramètres, Développeur).",
+      "api_rejected": "Zendure a rejeté la requête : {detail}",
+      "no_devices": "Jeton accepté, mais aucun appareil n'a été trouvé sur ce compte. Assurez-vous d'utiliser le compte Zendure sur lequel l'appareil est enregistré, ainsi que la bonne région.",
+      "no_mqtt": "Jeton accepté, mais aucun serveur MQTT n'a été renvoyé. Activez le MQTT local ou cloud pour ce compte dans l'application Zendure.",
       "invalid_auth": "Authentification invalide",
       "unknown": "Erreur inattendue"
     },

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -5,7 +5,11 @@
       "reconfigure_successful": "Hergroepering geslaagd"
     },
     "error": {
-      "cannot_connect": "Verbinding mislukt",
+      "cannot_connect": "De Zendure-API is niet bereikbaar. Controleer je internetverbinding en probeer het opnieuw.",
+      "malformed_token": "Het token is ongeldig. Kopieer het Home Assistant-token opnieuw uit de Zendure-app (Instellingen, Ontwikkelaar).",
+      "api_rejected": "Zendure heeft het verzoek geweigerd: {detail}",
+      "no_devices": "Token geaccepteerd, maar er zijn geen apparaten gevonden op dit account. Zorg dat je het Zendure-account gebruikt waarop het apparaat is geregistreerd, en de juiste regio.",
+      "no_mqtt": "Token geaccepteerd, maar er is geen MQTT-server teruggegeven. Schakel lokale of cloud-MQTT in voor dit account in de Zendure-app.",
       "invalid_auth": "Ongeldige authenticatie",
       "unknown": "Onverwachte fout"
     },


### PR DESCRIPTION
## Problem

Every setup failure in the config flow surfaced as the literal string `invalid input` (not even a translation key). The most common real causes are indistinguishable to the user:

- a **malformed / wrong token** (truncated paste, not the HA token), and
- a **valid token on an account or region that has no devices** (`deviceList: []`)

both looked identical to a genuine auth error. This is the root of the confusion in #1310, #1263, #1390, and the "SF800 Pro2 not supported" complaints (#1469) — which are actually token/account setup failures, not device-support gaps.

## Change

`api.py` now raises a typed `ApiError` carrying a translation key per distinct failure:

| key | when |
|---|---|
| `malformed_token` | token missing, not base64, or not the expected `<url>.<appKey>` shape |
| `cannot_connect` | network error reaching the API |
| `api_rejected` | API returned non-200 / `success=false` (Zendure's own `msg` passed through as `{detail}`) |
| `no_devices` | valid token but empty `deviceList` (wrong account/region) |
| `no_mqtt` | valid token but no MQTT server returned |

`Api.Connect` re-raises `ApiError` for the config flow (`reload=False`) and keeps the silent storage-fallback for coordinator reloads (`reload=True`), so **runtime behaviour is unchanged** — only the setup/reconfigure UI gets better messages.

`config_flow.py` maps each `ApiError.key` to a translated message across all three steps (user / local / reconfigure), with `{detail}` placeholders.

New error strings added to en / de / fr / nl.

## Not covered

This does not add SF800 Pro2 device support or change device detection — it only makes the setup failure explain itself. The Pro2 "no devices" reports appear to be account/region issues on the Zendure side; with this change those users will at least see *"no devices found on this account, check the account and region"* instead of *"invalid input"*.

## Testing

Syntax + JSON validated. Behavioural testing of the config flow against a live token still recommended before merge.