### PR TITLE
Reactivate rename migration to restore state after 1.4.0 +->_plus change

### DIFF
--- a/custom_components/zendure_ha/__init__.py
+++ b/custom_components/zendure_ha/__init__.py
@@ -20,10 +20,10 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> bool:
     """Migrate config entry to new version."""
-    if entry.version == 1 and entry.minor_version < 5:
+    if entry.version == 1 and entry.minor_version < 8:
         _LOGGER.info("Migrating Zendure config entry from version %s.%s", entry.version, entry.minor_version)
         await Migration.async_migrate(hass, entry.entry_id)
-    hass.config_entries.async_update_entry(entry, version=1, minor_version=5)
+    hass.config_entries.async_update_entry(entry, version=1, minor_version=8)
     return True
 
 

--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -36,7 +36,7 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Zendure Integration."""
 
     VERSION = 1
-    MINOR_VERSION = 7
+    MINOR_VERSION = 8
     _input_data: dict[str, Any]
     data_schema = vol.Schema(
         {


### PR DESCRIPTION
## Problem (#1477, #1475)

1.4.0's snakecase `+` -> `_plus` change altered the `unique_id`s and `entity_id`s of every entity on devices whose name contains `+` (SolarFlow 2400 AC+, 1600 AC+, 4000 AC+).

1.4.1's `check_entities` fix converges the registry ids (no more `_2` duplicates), but it **cannot move RestoreEntity state**, which is keyed by `entity_id`. So on upgrade the device-level selects lost their restored values and fell back to defaults:

- `connection` -> **cloud** (was local): device never reaches `CONNECTED`, so the manager reports *"No devices online"*
- `fuse_group` -> **unused**: manager excludes the device from dispatch
- `aggr_*` lifetime counters reset to 0

This is why users are still broken on 1.4.1 (@smalldatach, @C-Samy), and why @Bashbob / @fipiblitz recovered by manually setting `fuse_group` back.

Full root-cause trace and test by **@qpaz** in #1477.

## Fix

The repo already contains `Migration.async_migrate`, which renames `entity_id` + `unique_id` + `translation_key` **together** and **moves restore state** (`data.last_states`) plus long-term statistics, recomputing target ids from the current `snakecase` (so it produces the `_plus` names). It also rewrites YAML references and re-persists restore state.

But its gate was dead code: it only ran for `minor_version < 5`, while the config flow declared `MINOR_VERSION = 7` — so it never fired for any 1.3.x install (entries sit at 5 or 7; HA doesn't even call `async_migrate_entry` when stored == declared).

This PR bumps `MINOR_VERSION` to 8 and gates the migration on `< 8` (pinning to 8 afterward), so the existing migration runs **once** on upgrade and restores state.

## Interaction with 1.4.1's check_entities

`async_migrate_entry` runs **before** `async_setup_entry`, so the migration completes (ids + restore state fixed) before `check_entities` runs during device init. check_entities then finds everything already canonical and does nothing — no conflict. For installs already broken by 1.4.0, the migration also converges the registry (removes squatters, renames `_2` back), though counter values already reset on 1.4.0 are not recoverable.

## Testing

@qpaz ran exactly this change on a live SF2400 AC+ install: 70 entities renamed (entity_id + unique_id together), `aggr_*` counters kept their values, selects kept local/fuse-group, recorder history + statistics migrated with zero warnings, YAML refs rewritten, device online throughout. **Please still verify one upgrade on a real 1.3.x/1.4.x install before merge.**