### PR TITLE
Reduce idle during power fluctuations

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -71,3 +71,4 @@ class SmartMode:
 
     POWER_START = 50  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
+    POWER_IDLE = 10  # Minimal hold power (W) during the direction switch timeout; must exceed POWER_TOLERANCE so the stop command is not skipped

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -72,3 +72,4 @@ class SmartMode:
     POWER_START = 50  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
     POWER_IDLE = 10  # Minimal hold power (W) during the direction switch timeout; must exceed POWER_TOLERANCE so the stop command is not skipped
+    HOLD_TIMEOUT = 300  # Seconds after a direction flip during which another flip is considered likely

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -536,6 +536,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             else:
                 # avoid gridOff device to use power from the grid
                 await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
+                # a device parked at hold power can be restarted right away
+                if d.pwr_offgrid == 0 and d.homeOutput.asInt <= SmartMode.POWER_IDLE:
+                    self.idle.append(d)
 
         self.operationstate.update_value(ManagerState.CHARGE.value if setpoint < 0 else ManagerState.IDLE.value)
 
@@ -614,6 +617,9 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             else:
                 # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
                 await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
+                # a device parked at hold power can be restarted right away
+                if max(0, d.pwr_offgrid) == 0 and d.homeInput.asInt <= SmartMode.POWER_IDLE:
+                    self.idle.append(d)
 
         # distribute discharging devices, use produced power first, before adding another device
         dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -514,21 +514,28 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         """Charge devices."""
         _LOGGER.info("Charge => setpoint %sW", setpoint)
 
-        # stop discharging devices
-        for d in self.discharge:
-            # avoid stopping bypassing devices
-            if d.byPass.asInt > 0:
-                continue
-            # avoid gridOff device to use power from the grid
-            await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
-
         # prevent hysteria
-        if self.charge_time > time:
+        if hold := self.charge_time > time:
             if self.charge_time == datetime.max:
                 self.charge_time = time + timedelta(seconds=2 if (time - self.charge_last).total_seconds() > 300 else 60)
                 self.charge_last = self.charge_time
                 self.pwr_low = 0
             setpoint = 0
+
+        # Stop discharging devices. While the switch timeout is running, keep them
+        # discharging at minimal power instead of going idle, so a temporary grid
+        # fluctuation (e.g. a slow ramping EV charger) can resume discharging
+        # immediately without an idle period or an extra mode switch (#1461).
+        for d in self.discharge:
+            # avoid stopping bypassing devices
+            if d.byPass.asInt > 0:
+                continue
+            if hold and d.pwr_offgrid == 0 and d.state != DeviceState.SOCEMPTY:
+                await d.power_discharge(SmartMode.POWER_IDLE)
+            else:
+                # avoid gridOff device to use power from the grid
+                await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
+
         self.operationstate.update_value(ManagerState.CHARGE.value if setpoint < 0 else ManagerState.IDLE.value)
 
         # distribute charging devices

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -77,6 +77,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.charge_weight = 0
 
         self.discharge: list[ZendureDevice] = []
+        self.discharge_time = datetime.min
         self.discharge_bypass = 0
         self.discharge_produced = 0
         self.discharge_limit = 0
@@ -486,24 +487,24 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 if setpoint < 0:
                     await self.power_charge(setpoint, time)
                 else:
-                    await self.power_discharge(setpoint)
+                    await self.power_discharge(setpoint, time)
 
             case ManagerMode.MATCHING_DISCHARGE:
                 # Only discharge, do nothing if setpoint is negative
-                await self.power_discharge(max(0, setpoint))
+                await self.power_discharge(max(0, setpoint), time)
 
             case ManagerMode.MATCHING_CHARGE | ManagerMode.STORE_SOLAR:
                 # Allow discharge of produced power in MATCHING_CHARGE-Mode, otherwise only charge
                 # d.pwr_produced is negative, but self.produced is positive
                 if setpoint > 0 and self.produced > SmartMode.POWER_START and self.operation == ManagerMode.MATCHING_CHARGE:
-                    await self.power_discharge(min(self.produced, setpoint))
+                    await self.power_discharge(min(self.produced, setpoint), time)
                 else:
                     await self.power_charge(min(0, setpoint), time)
 
             case ManagerMode.MANUAL:
                 # Manual power into or from home
                 if (setpoint := int(self.manualpower.asNumber)) > 0:
-                    await self.power_discharge(setpoint)
+                    await self.power_discharge(setpoint, time)
                 else:
                     await self.power_charge(setpoint, time)
 
@@ -517,7 +518,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         # prevent hysteria
         if hold := self.charge_time > time:
             if self.charge_time == datetime.max:
-                self.charge_time = time + timedelta(seconds=2 if (time - self.charge_last).total_seconds() > 300 else 60)
+                self.charge_time = time + timedelta(seconds=2 if (time - self.charge_last).total_seconds() > SmartMode.HOLD_TIMEOUT else 60)
                 self.charge_last = self.charge_time
                 self.pwr_low = 0
             setpoint = 0
@@ -537,6 +538,14 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 await d.power_discharge(0 if d.pwr_offgrid == 0 else -10)
 
         self.operationstate.update_value(ManagerState.CHARGE.value if setpoint < 0 else ManagerState.IDLE.value)
+
+        # While the switch timeout is running, keep devices that are still in charge
+        # mode at minimal input instead of stopping them, so charging can resume
+        # immediately once the timeout expires, without a mode switch (#1461).
+        if hold:
+            for d in self.charge:
+                await d.power_charge(-SmartMode.POWER_IDLE if d.pwr_offgrid == 0 and d.state != DeviceState.SOCFULL else 0)
+            return
 
         # distribute charging devices
         dev_start = min(0, setpoint - self.charge_optimal * 2) if setpoint < -SmartMode.POWER_START else 0
@@ -583,7 +592,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     break
             self.pwr_low: int = 0
 
-    async def power_discharge(self, setpoint: int) -> None:
+    async def power_discharge(self, setpoint: int, time: datetime) -> None:
         """Discharge devices."""
         _LOGGER.info("Discharge => setpoint %sW", setpoint)
         self.operationstate.update_value(ManagerState.DISCHARGE.value if setpoint > 0 and self.discharge else ManagerState.IDLE.value)
@@ -592,11 +601,19 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         if self.charge_time != datetime.max:
             self.charge_time = datetime.max
             self.pwr_low = 0
+            self.discharge_time = time + timedelta(seconds=SmartMode.HOLD_TIMEOUT)
 
-        # stop charging devices
+        # Stop charging devices. While a flip back to charging is likely and the
+        # discharging devices can cover the setpoint on their own, keep the chargers
+        # at minimal input instead, so charging can resume without an idle period
+        # or an extra mode switch (#1461).
+        hold = time < self.discharge_time and (setpoint < SmartMode.POWER_START or setpoint <= self.discharge_limit)
         for d in self.charge:
-            # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
-            await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
+            if hold and max(0, d.pwr_offgrid) == 0 and d.state != DeviceState.SOCFULL:
+                await d.power_charge(-SmartMode.POWER_IDLE)
+            else:
+                # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
+                await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
 
         # distribute discharging devices, use produced power first, before adding another device
         dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0


### PR DESCRIPTION
Implements #1461: during rapid grid direction flips (e.g. a slowly ramping EV charger), the battery no longer sits fully idle in the anti-hysteresis hold-off window. Instead, devices are kept at a minimal power of ±10 W (`SmartMode.POWER_IDLE`) so they stay in their current inverter mode and can resume full power instantly, without extra mode switches.

Flip to charging: during the 60 s hold-off window, devices that were discharging are held at +10 W instead of being stopped. If the grid flips back to export before the window expires, they ramp straight back up — no idle period, no cold start, no mode switch.
Flip to discharging: charging devices are held at -10 W for up to `HOLD_TIMEOUT ` (300 s, the same horizon already used to arm the 60 s window), but only when the discharging devices can cover the setpoint on their own. If more power is needed, they are released immediately, exactly as before. Held devices never leave charge mode, so charging resumes with no idle period at all once the window expires.
Offgrid (SF 2400), SOC-full and SOC-empty devices keep the previous behavior. `POWER_IDLE ` is 10 W rather than the ±1 W suggested in the issue because it must exceed `POWER_TOLERANCE ` (5 W), otherwise the stop command at the end of a hold would be swallowed by the device-level tolerance check.
Testing
Simulated the real `powerChanged/power_charge/power_discharge` code (HA 2026.2, fake devices reproducing the device-level clamp/tolerance logic, 2 s update ticks) and compared this branch tick-by-tick against master, with 1 and 2 devices:

- **Charge → discharge flip (800 W demand)**: identical to master at every tick — the hold never delays a needed discharge, since chargers are released whenever discharging devices can't cover the setpoint.
- **Discharge → charge flip**: identical timing to master, including at the expiry of the 60 s window (a one-cycle delay found during testing is fixed by re-adding parked devices to the idle list so they restart in the same update).
- **EV-charger fluctuation (±300 W every 15 s for 5 min)**: inverter mode switches drop from 22 to 3, MQTT commands from 33 to 24, and discharge resumes instantly at full power on each flip back (master: idle → 50 W kickstart → full power ~4 s later). Mean residual grid power slightly improves (160 W → 150 W).
- Cost of the trade-off: at most ~10 W flowing during a hold window (≈0.17 Wh per 60 s window); total energy charged/discharged in the flip scenarios is unchanged vs master.

Fixes [#1461](https://github.com/zoic21/Zendure-HA/issues/1461)

Other
I think it's need to be test because leave 10W inplace of idle is beter to restart faster charge/discharge but it's consume 0,0001667 kWh (about 0,167 Wh), it's small but not 0.