### PR TITLE
Send full command incl. smartMode/acMode for zenSDK limit writes

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -745,7 +745,15 @@ class ZendureZenSdk(ZendureDevice):
             _LOGGER.error("Entity %s has no translation_key, cannot write property %s", entity.name, self.name)
             return
 
-        if self.online and self.connection.value == 0:
+        # Route limit writes through the power routines so they send the full command
+        # (smartMode/acMode), exactly like the manager does. A bare outputLimit/inputLimit
+        # property write is silently ignored when the device has dropped out of smart mode
+        # (observed on SolarFlow 2400 Pro at 100% SoC, see #1505).
+        if entity.propertyName == "outputLimit":
+            await self.discharge(value)
+        elif entity.propertyName == "inputLimit":
+            await self.charge(-value)
+        elif self.online and self.connection.value == 0:
             await super().entityWrite(entity, value)
         else:
             _LOGGER.info("Writing property %s %s => %s", self.name, entity.propertyName, value)


### PR DESCRIPTION
## Problem

When an external controller (automation, energy-management add-on, …) writes `number.output_limit` or `number.input_limit`, `ZendureZenSdk.entityWrite` posts only the bare property:

```json
{"properties": {"outputLimit": 800}}
```

The integration's own control path (`discharge()` / `charge()`) always sends the full command including `smartMode` and `acMode`.

A bare limit write is **silently ignored** when the device has dropped out of smart mode. Observed on a SolarFlow 2400 Pro at 100% SoC (see #1505): the device stopped discharging (0 W output), kept reporting telemetry normally, but ignored every subsequent `outputLimit` write for over 90 minutes. Recovery was only possible by re-asserting the full command (`smartMode: 1, acMode: 2, …`) against the local API.

## Fix

Route `outputLimit` / `inputLimit` writes through `doCommand()` with the same full payload that `discharge()` / `charge()` use, so every external write re-asserts `smartMode`/`acMode`. `doCommand()` also keeps the cloud/zenSDK transport distinction intact (MQTT publish vs. local HTTP).

The `smartMode: 0` case for `value == 0` (with no off-grid power) mirrors `power_off()`.

## Testing

- Reproduced the hang on a SolarFlow 2400 Pro (FW-state after ramping `outputLimit` to 2400 W at 100% SoC): bare property writes ignored, full command accepted.
- Verified the full-command payload live against the device's local `properties/write` endpoint: discharge resumed and the device accepted the full 2400 W again.

Fixes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
