### PR TITLE
fix(manager): feed all available solar at SOCFULL instead of stalling…

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -430,6 +430,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             if await d.power_get():
                 # get power production
                 d.pwr_produced = min(0, d.batteryOutput.asInt + d.homeInput.asInt - d.batteryInput.asInt - d.homeOutput.asInt)
+                if d.state == DeviceState.SOCFULL and -d.solarInput.asInt < d.pwr_produced:
+                    d.pwr_produced = -d.solarInput.asInt
                 self.produced -= d.pwr_produced
 
                 # only positive pwr_offgrid must be taken into account, negative values count a solarInput


### PR DESCRIPTION
… at POWER_START

At SOCFULL the inverter curtails its panels to the currently commanded homeOutput. pwr_produced is derived from that measured output, so once a device is started at POWER_START (~50 W) the production reads ~50 W, the manager commands ~50 W again and the loop never ramps up — even when the roof (and the house) could take far more, and export is forbidden.

Use the actual solarInput as the real available production for SOCFULL devices. It stays bounded by setpoint (home demand) and discharge_limit downstream, so the battery is never drained and export remains governed by gridReverse; only the solar pass-through is allowed to ramp to what the roof can deliver.