### PR TITLE
fix(device): treat gridReverse "disabled" as no-export for SOCFULL bypass

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -265,7 +265,7 @@ class ZendureDevice(EntityDevice):
                             self.nextCalibration.update_value(dt_util.now() + timedelta(days=30))
                         self.availableKwh.update_value((self.electricLevel.asNumber - self.minSoc.asNumber) / 100 * self.kWh)
                     case "gridReverse":
-                        self.exports_bypass = value != 2
+                        self.exports_bypass = value == 1
         except Exception as e:
             _LOGGER.error("EntityUpdate error %s %s %s!", self.name, key, e)
             _LOGGER.error(traceback.format_exc())


### PR DESCRIPTION
exports_bypass gates whether a SOCFULL device's non-dispatchable solar bypass is subtracted from the setpoint, which is only correct when the device may actually export. Commit ecb87b5 moved the gridReverse check into this eager bool but changed its meaning from
`grid_reverse in (None, 1, "allow")` to `value != 2`.

That regressed the "disabled" (0) option: it is now treated as export-allowed, so the bypass subtraction kicks in even though no export is possible, and a full battery can no longer follow the requested output. Only "allow" (1) should enable the bypass accounting; both "disabled" (0) and "forbidden" (2) mean no export.

Restore the original intent: exports_bypass = value == 1.