### PR TITLE
fix: manager mode select and ACE 1500 device failing to load

### DIFF
--- a/custom_components/zendure_ha/entity.py
+++ b/custom_components/zendure_ha/entity.py
@@ -275,6 +275,10 @@ class EntityDevice:
         from .sensor import ZendureCalcSensor, ZendureSensor
         from .switch import ZendureSwitch
 
+        if not snakecase(key):
+            _LOGGER.warning("Ignoring unusable property key %r for %s", key, self.name)
+            return False
+
         # check if entity is already created
         if (entity := self.entities.get(key, None)) is None:
             if info := self.createEntity.get(key, None):

--- a/custom_components/zendure_ha/select.py
+++ b/custom_components/zendure_ha/select.py
@@ -103,9 +103,11 @@ class ZendureRestoreSelect(ZendureSelect, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-        if state := await self.async_get_last_state():
+
+        state = await self.async_get_last_state()
+        if state is not None and state.state in self._attr_options:
             self._attr_current_option = state.state
-        else:
+        elif self._attr_current_option not in self._attr_options:
             self._attr_current_option = self._attr_options[0]
 
         # do the onchanged callback


### PR DESCRIPTION
After upgrading the integration to the newest one (1.4.3) and probably due to dirty state in HA the following issues occurred:

### Entity select.zendure_manager_operation never added

ZendureRestoreSelect.async_added_to_hass assigned the restored state straight to _attr_current_option without checking it was still a valid option. When the state was unavailable, value returned None and ManagerMode(None) raised inside the callback:

```
ERROR [homeassistant.components.select] Error adding entity select.zendure_manager_operation for domain select with platform zendure_ha
  File "/config/custom_components/zendure_ha/select.py", line 114, in async_added_to_hass
  File "/config/custom_components/zendure_ha/manager.py", line 254, in update_operation
```

The only adopt a restored state that is one of the current options; otherwise keep the default the constructor already chose

### ACE 1500 device failed to load

The ACE 1500 published a property whose key was the empty string. 
entityUpdate turned it into a sensor with unique_id=ace_1500 and an empty translation_key. check_entities tried to migrate that entry to sensor.ace_1500_  , which HA rejects and in result the ValueError aborted construction of the entire device

```
INFO  [entity]  Update entity sensor.ace_1500_
INFO  [entity]  Migrating entity sensor.ace_1500 -> sensor.ace_1500_ (unique_id ace_1500 -> ace_1500_)
ERROR [manager] Unable to create device Invalid entity ID!
  File ".../manager.py", line 128, in loadDevices
  File ".../devices/ace1500.py", line 25, in __init__
  File ".../entity.py", line 231, in __init__
  File ".../entity.py", line 267, in check_entities
```
