### PR TITLE
Add local (cloud-free) device onboarding/configuration

### DIFF
--- a/custom_components/zendure_ha/__init__.py
+++ b/custom_components/zendure_ha/__init__.py
@@ -7,7 +7,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .api import Api
-from .const import CONF_MQTTLOG, CONF_P1METER, CONF_SIM
+from .const import (
+    CONF_DEVICE_SN,
+    CONF_DEVICES,
+    CONF_LOCAL_ONLY,
+    CONF_MQTTLOG,
+    CONF_P1METER,
+    CONF_SIM,
+)
 from .device import ZendureDevice
 from .entity import EntityDevice
 from .manager import ZendureConfigEntry, ZendureManager
@@ -64,17 +71,38 @@ async def async_unload_entry(hass: HomeAssistant, entry: ZendureConfigEntry) -> 
         manager.update_p1meter(None)
         manager.fuseGroups.clear()
         manager.devices.clear()
+        # Api.devices is class-level state that survives a reload; clear it so the
+        # next setup rebuilds the authoritative set from the (cloud or local) device
+        # list and a removed device does not linger.
+        Api.devices.clear()
     return result
 
 
-async def async_remove_config_entry_device(_hass: HomeAssistant, entry: ZendureConfigEntry, device_entry: dr.DeviceEntry) -> bool:
+async def async_remove_config_entry_device(hass: HomeAssistant, entry: ZendureConfigEntry, device_entry: dr.DeviceEntry) -> bool:
     """Remove a device from a config entry."""
     manager = entry.runtime_data
 
     # check for device to remove
     for d in manager.devices:
         if d.name == device_entry.name:
+            # A local entry has no cloud account to fall back on, so it can't be left
+            # with zero devices. Checked against manager.devices (the live set), not
+            # entry.data[CONF_DEVICES], since a failed-to-load device would inflate
+            # the persisted count and bypass this guard.
+            if entry.data.get(CONF_LOCAL_ONLY) and len(manager.devices) <= 1:
+                _LOGGER.error(
+                    "Cannot remove %s: it is the only device on this local Zendure entry. Remove the Zendure integration entry instead.",
+                    d.name,
+                )
+                return False
+
             manager.devices.remove(d)
+            Api.devices.pop(d.deviceId, None)
+            # For a local entry, also drop it from the stored list so it does not
+            # reappear on the next reload. Cloud entries are re-fetched, so leave them.
+            if entry.data.get(CONF_LOCAL_ONLY):
+                devices = [x for x in entry.data.get(CONF_DEVICES, []) if str(x.get(CONF_DEVICE_SN)) != d.deviceId]
+                hass.config_entries.async_update_entry(entry, data={**entry.data, CONF_DEVICES: devices})
             return True
 
         if isinstance(d, ZendureDevice) and (bat := next((b for b in d.batteries.values() if b.name == device_entry.name), None)) is not None:

--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any, Mapping
 
+from aiohttp import ClientTimeout
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
@@ -21,7 +22,13 @@ from paho.mqtt import enums as mqtt_enums
 
 from .const import (
     CONF_APPTOKEN,
+    CONF_DEVICE_IP,
+    CONF_DEVICE_MODEL,
+    CONF_DEVICE_NAME,
+    CONF_DEVICE_SN,
+    CONF_DEVICES,
     CONF_HAKEY,
+    CONF_LOCAL_ONLY,
     CONF_MQTTLOG,
     CONF_MQTTPORT,
     CONF_MQTTPSW,
@@ -85,6 +92,8 @@ class Api:
         "solarflow2400ac+": SolarFlow2400AC_Plus,
         "solarflow2400pro": SolarFlow2400Pro,
         "solarflow4000ac+": SolarFlow4000AC_Plus,
+        # SF4000 Mix reports its model as "solarFlow4000MixAC+" locally, it's the same hardware as the AC+
+        "solarflow4000mixac+": SolarFlow4000AC_Plus,
         "superbasev6400": SuperBaseV6400,
         "superbasev4600": SuperBaseV4600,
     }
@@ -104,10 +113,16 @@ class Api:
     def Init(self, data: Mapping[str, Any], mqtt: Mapping[str, Any]) -> None:
         """Initialize Zendure Api."""
         Api.mqttLogging = data.get(CONF_MQTTLOG, False)
-        Api.mqttCloud.__init__(mqtt_enums.CallbackAPIVersion.VERSION2, mqtt["clientId"], False, "cloud", mqtt_enums.MQTTProtocolVersion.MQTTv31)
-        url = mqtt["url"]
-        Api.cloudServer, Api.cloudPort = url.rsplit(":", 1) if ":" in url else (url, "1883")
-        self.mqttInit(Api.mqttCloud, Api.cloudServer, Api.cloudPort, mqtt["username"], mqtt["password"])
+
+        # `mqtt` carries the cloud broker credentials returned by the Zendure cloud
+        # API. The local (zenSDK) setup makes no cloud call, so it is empty and that
+        # device is driven entirely over its on-device HTTP API - no MQTT needed.
+        # Only connect the cloud broker when those credentials are present.
+        if mqtt:
+            Api.mqttCloud.__init__(mqtt_enums.CallbackAPIVersion.VERSION2, mqtt["clientId"], False, "cloud", mqtt_enums.MQTTProtocolVersion.MQTTv31)
+            url = mqtt["url"]
+            Api.cloudServer, Api.cloudPort = url.rsplit(":", 1) if ":" in url else (url, "1883")
+            self.mqttInit(Api.mqttCloud, Api.cloudServer, Api.cloudPort, mqtt["username"], mqtt["password"])
 
         # Get wifi settings
         Api.wifissid = data.get(CONF_WIFISSID, "")
@@ -126,6 +141,12 @@ class Api:
     @staticmethod
     async def Connect(hass: HomeAssistant, data: dict[str, Any], reload: bool) -> dict[str, Any] | None:
         """Connect to the Zendure API."""
+        # Local (cloud-free) setup: the device list is described entirely by the
+        # config entry, so there is no cloud call to make. The device talks to us
+        # over its on-device Zen SDK HTTP API instead.
+        if data.get(CONF_LOCAL_ONLY):
+            return Api.localDeviceList(data)
+
         try:
             devices = await Api.ApiHA(hass, data)
         except ApiError:
@@ -220,6 +241,59 @@ class Api:
             _LOGGER.error("Zendure API does not reply any mqtt info: %s", data)
             raise ApiError("no_mqtt")
         return dict(result)
+
+    @staticmethod
+    def localDeviceList(data: Mapping[str, Any]) -> dict[str, Any]:
+        """Build a cloud-free device list from a local config entry."""
+        # Mirrors the shape ApiHA returns so the rest of the integration is unaware
+        # whether the device came from the cloud or from local config. The empty
+        # mqtt block signals the manager to skip cloud MQTT setup.
+        deviceList = []
+        for dev in data.get(CONF_DEVICES, []):
+            sn = str(dev.get(CONF_DEVICE_SN, "")).strip()
+            model = str(dev.get(CONF_DEVICE_MODEL, "")).strip()
+            ip = str(dev.get(CONF_DEVICE_IP, "")).strip()
+            name = str(dev.get(CONF_DEVICE_NAME, "") or model).strip()
+            if not sn or not ip:
+                continue
+            deviceList.append({
+                "deviceKey": sn,
+                "productModel": model,
+                "productKey": "local",
+                "snNumber": sn,
+                "deviceName": name,
+                "ip": ip,
+                "local": True,
+            })
+
+        if not deviceList:
+            # Mirrors ApiHA's ApiError("no_devices") diagnostic: a local entry with no
+            # usable devices would otherwise "load successfully" with zero entities and
+            # no indication in the log of why.
+            _LOGGER.error("Local Zendure entry has no usable devices in its stored device list: %s", data.get(CONF_DEVICES, []))
+
+        return {
+            "deviceList": deviceList,
+            "mqtt": {},
+        }
+
+    @staticmethod
+    async def testLocalDevice(hass: HomeAssistant, ip: str) -> tuple[str, str]:
+        """Validate a local device via its Zen SDK report; return (serial, product)."""
+        # Raises ApiError with a config-flow translation key on failure. The product
+        # string (e.g. "solarFlow4000MixAC+") lets the config flow auto-detect the model.
+        session = async_get_clientsession(hass, verify_ssl=False)
+        try:
+            response = await session.get(f"http://{ip}/properties/report", timeout=ClientTimeout(total=5))
+            payload = await response.json(content_type=None)
+        except Exception as e:
+            _LOGGER.error("Unable to reach local Zendure device at %s: %s", ip, e)
+            raise ApiError("cannot_connect_local", str(e)) from e
+
+        if not isinstance(payload, dict) or not (sn := payload.get("sn")):
+            _LOGGER.error("Local Zendure device at %s returned an unexpected report: %s", ip, payload)
+            raise ApiError("no_local_report")
+        return str(sn), str(payload.get("product", ""))
 
     def mqttInit(self, client: mqtt_client.Client, srv: str, port: str, user: str, psw: str) -> None:
         try:

--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -15,6 +15,12 @@ from .api import Api, ApiError
 from .const import (
     CONF_APPTOKEN,
     CONF_AUTO_MQTT_USER,
+    CONF_DEVICE_IP,
+    CONF_DEVICE_MODEL,
+    CONF_DEVICE_NAME,
+    CONF_DEVICE_SN,
+    CONF_DEVICES,
+    CONF_LOCAL_ONLY,
     CONF_MQTTLOCAL,
     CONF_MQTTLOG,
     CONF_MQTTPORT,
@@ -27,6 +33,7 @@ from .const import (
     CONF_WIFISSID,
     DOMAIN,
 )
+from .device import ZendureZenSdk
 from .manager import ZendureConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,13 +72,38 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         }
     )
+    # Per-device fields only; the entry-level settings (P1 meter, logging) are asked
+    # once at the end of the add-loop, not per device.
+    localsdk_device_schema = vol.Schema(
+        {
+            vol.Required(CONF_DEVICE_IP): str,
+            vol.Optional(CONF_DEVICE_NAME): str,
+        }
+    )
+    localsdk_settings_schema = vol.Schema(
+        {
+            vol.Required(CONF_P1METER, description={"suggested_value": "sensor.power_actual"}): selector.EntitySelector(),
+            vol.Required(CONF_MQTTLOG, default=False): bool,
+        }
+    )
 
     def __init__(self) -> None:
         """Initialize."""
         self._user_input: dict[str, Any] = {}
+        # Local (cloud-free) devices accumulated across the add-loop / reconfigure.
+        self._devices: list[dict[str, Any]] = []
+        self._devices_loaded = False
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Step when user initializes a integration."""
+    async def async_step_user(self, _user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Let the user choose between cloud and local (cloud-free) setup."""
+        # Only one Zendure entry is supported; abort up front so the user does not
+        # walk the whole (possibly multi-device) flow only to be rejected at the end.
+        await self.async_set_unique_id("Zendure", raise_on_progress=False)
+        self._abort_if_unique_id_configured()
+        return self.async_show_menu(step_id="user", menu_options=["cloud", "localsdk"])
+
+    async def async_step_cloud(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Step for the cloud (token based) setup."""
         errors: dict[str, str] = {}
         placeholders: dict[str, str] = {}
         if user_input is not None:
@@ -94,7 +126,96 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title="Zendure", data=self._user_input)
 
-        return self.async_show_form(step_id="user", data_schema=self.data_schema, errors=errors, description_placeholders=placeholders)
+        return self.async_show_form(step_id="cloud", data_schema=self.data_schema, errors=errors, description_placeholders=placeholders)
+
+    @staticmethod
+    def _resolve_model(product: str) -> str | None:
+        """Return the ZenSDK model key auto-detected from the device's reported product string."""
+        # Only accept models whose device class is a ZendureZenSdk subclass: a
+        # legacy/cloud-only model here would build a device class that ignores
+        # definition["local"] and never comes online.
+        key = str(product).lower().replace(" ", "")
+        cls = Api.createdevice.get(key)
+        return key if cls is not None and issubclass(cls, ZendureZenSdk) else None
+
+    async def _validate_device(self, user_input: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, str]]:
+        """Reach the device, resolve its model, and return a device dict (or errors)."""
+        errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
+        ip = str(user_input[CONF_DEVICE_IP]).strip()
+        try:
+            sn, product = await Api.testLocalDevice(self.hass, ip)
+        except ApiError as err:
+            errors["base"] = err.key
+            placeholders["detail"] = err.detail
+            return None, errors, placeholders
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error("Unexpected exception: %s", err)
+            errors["base"] = "unknown"
+            return None, errors, placeholders
+
+        model = self._resolve_model(product)
+        if model is None:
+            errors["base"] = "unsupported_model"
+            placeholders["detail"] = product or "unknown"
+            return None, errors, placeholders
+
+        if any(str(d.get(CONF_DEVICE_SN)) == sn for d in self._devices):
+            errors["base"] = "duplicate_device"
+            placeholders["detail"] = sn
+            return None, errors, placeholders
+
+        # Keep the device name unique: first append the serial suffix, then a
+        # counter, so a secondary collision cannot produce two identical names.
+        base = str(user_input.get(CONF_DEVICE_NAME, "") or "").strip() or model
+        existing = {str(d.get(CONF_DEVICE_NAME)) for d in self._devices}
+        name = base
+        if name in existing:
+            name = f"{base} {sn[-4:]}"
+            i = 2
+            while name in existing:
+                name = f"{base} {sn[-4:]} ({i})"
+                i += 1
+
+        return {CONF_DEVICE_IP: ip, CONF_DEVICE_SN: sn, CONF_DEVICE_MODEL: model, CONF_DEVICE_NAME: name}, errors, placeholders
+
+    async def async_step_localsdk(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Add one local (cloud-free) device via its on-device Zen SDK HTTP API."""
+        errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
+        if user_input is not None:
+            device, errors, placeholders = await self._validate_device(user_input)
+            if device is not None:
+                self._devices.append(device)
+                return await self.async_step_localsdk_menu()
+
+        return self.async_show_form(step_id="localsdk", data_schema=self.localsdk_device_schema, errors=errors, description_placeholders=placeholders)
+
+    async def async_step_localsdk_menu(self, _user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Offer to add another local device or finish the setup."""
+        return self.async_show_menu(
+            step_id="localsdk_menu",
+            menu_options=["localsdk", "localsdk_settings"],
+            description_placeholders={
+                "count": str(len(self._devices)),
+                "devices": ", ".join(str(d.get(CONF_DEVICE_NAME, "")) for d in self._devices),
+            },
+        )
+
+    async def async_step_localsdk_settings(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Ask the entry-level settings once and create the local config entry."""
+        if user_input is not None:
+            data = {
+                CONF_LOCAL_ONLY: True,
+                CONF_DEVICES: self._devices,
+                CONF_P1METER: user_input[CONF_P1METER],
+                CONF_MQTTLOG: user_input[CONF_MQTTLOG],
+            }
+            await self.async_set_unique_id("Zendure", raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title="Zendure", data=data)
+
+        return self.async_show_form(step_id="localsdk_settings", data_schema=self.localsdk_settings_schema)
 
     async def async_step_local(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
@@ -121,6 +242,8 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         entry = self._get_reconfigure_entry()
+        if entry.data.get(CONF_LOCAL_ONLY):
+            return await self.async_step_reconfigure_local(user_input)
         schema = self.data_schema
         placeholders: dict[str, str] = {}
         if user_input is not None:
@@ -152,6 +275,72 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders=placeholders,
         )
+
+    def _load_local_devices(self) -> None:
+        """Seed the working device list from the entry the first time we enter reconfigure."""
+        if self._devices_loaded:
+            return
+        entry = self._get_reconfigure_entry()
+        self._devices = [dict(d) for d in entry.data.get(CONF_DEVICES, [])]
+        self._devices_loaded = True
+
+    async def async_step_reconfigure_local(self, _user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Manage the local device list: add, remove, or save and reload."""
+        self._load_local_devices()
+        return self.async_show_menu(
+            step_id="reconfigure_local",
+            menu_options=["reconfig_add", "reconfig_remove", "reconfig_save"],
+            description_placeholders={
+                "count": str(len(self._devices)),
+                "devices": ", ".join(str(d.get(CONF_DEVICE_NAME, "")) for d in self._devices),
+            },
+        )
+
+    async def async_step_reconfig_add(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Add a device to an existing local config entry."""
+        errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
+        if user_input is not None:
+            device, errors, placeholders = await self._validate_device(user_input)
+            if device is not None:
+                self._devices.append(device)
+                return await self.async_step_reconfigure_local()
+
+        return self.async_show_form(step_id="reconfig_add", data_schema=self.localsdk_device_schema, errors=errors, description_placeholders=placeholders)
+
+    async def async_step_reconfig_remove(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Remove one or more devices from an existing local config entry."""
+        if not self._devices:
+            return await self.async_step_reconfigure_local()
+
+        if user_input is not None:
+            remove = set(user_input.get("remove", []))
+            self._devices = [d for d in self._devices if str(d.get(CONF_DEVICE_SN)) not in remove]
+            return await self.async_step_reconfigure_local()
+
+        options = [selector.SelectOptionDict(value=str(d.get(CONF_DEVICE_SN)), label=str(d.get(CONF_DEVICE_NAME))) for d in self._devices]
+        schema = vol.Schema(
+            {
+                vol.Required("remove"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=options, multiple=True, mode=selector.SelectSelectorMode.LIST),
+                ),
+            }
+        )
+        return self.async_show_form(step_id="reconfig_remove", data_schema=schema)
+
+    async def async_step_reconfig_save(self, _user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Persist the edited device list and reload the entry."""
+        entry = self._get_reconfigure_entry()
+        if not self._devices:
+            return self.async_abort(reason="no_devices_configured")
+
+        # Drop the legacy single-device keys so CONF_DEVICES is the single source of truth.
+        data = {k: v for k, v in entry.data.items() if k not in (CONF_DEVICE_IP, CONF_DEVICE_SN, CONF_DEVICE_MODEL, CONF_DEVICE_NAME)}
+        data[CONF_LOCAL_ONLY] = True
+        data[CONF_DEVICES] = self._devices
+        await self.async_set_unique_id("Zendure", raise_on_progress=False)
+        self._abort_if_unique_id_mismatch()
+        return self.async_update_reload_and_abort(entry, data=data)
 
     @staticmethod
     @callback

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -19,6 +19,15 @@ CONF_WIFISSID = "wifissid"
 CONF_WIFIPSW = "wifipsw"
 CONF_AUTO_MQTT_USER = "auto_mqtt_user"
 
+# Local (cloud-free) setup via the on-device Zen SDK HTTP API.
+CONF_LOCAL_ONLY = "local_only"
+CONF_DEVICE_IP = "device_ip"
+CONF_DEVICE_SN = "device_sn"
+CONF_DEVICE_MODEL = "device_model"
+CONF_DEVICE_NAME = "device_name"
+# List of local devices on a single config entry: [{ip, sn, model, name}, ...].
+CONF_DEVICES = "devices"
+
 CONF_HAKEY = "C*dafwArEOXK"
 
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -722,7 +722,14 @@ class ZendureZenSdk(ZendureDevice):
         """Initialize Device."""
         self.session = async_get_clientsession(hass, verify_ssl=False)
         super().__init__(hass, deviceId, name, model, definition, parent)
-        self.connection = ZendureRestoreSelect(self, "connection", {0: "cloud", 2: "zenSDK"}, self.mqttSelect, 0)
+        # A local (cloud-free) device has no cloud broker to fall back to: dataRefresh,
+        # power_get and doCommand all skip HTTP polling/writes once connection.value == 0,
+        # so picking "cloud" here would silently stop updates and drop every command. Only
+        # offer zenSDK for it, instead of just defaulting to zenSDK and leaving the option.
+        if definition.get("local"):
+            self.connection = ZendureRestoreSelect(self, "connection", {2: "zenSDK"}, self.mqttSelect, 2)
+        else:
+            self.connection = ZendureRestoreSelect(self, "connection", {0: "cloud", 2: "zenSDK"}, self.mqttSelect, 0)
         self.httpid = 0
 
     async def mqttSelect(self, select: Any, _value: Any) -> None:
@@ -760,7 +767,10 @@ class ZendureZenSdk(ZendureDevice):
             await self.httpPost("properties/write", {"properties": {entity.propertyName: value}})
 
     async def dataRefresh(self, update_count: int) -> None:
-        if update_count == 0 and not self.online:
+        # In zenSDK mode the device is not pushing MQTT updates, so poll its local
+        # HTTP report every cycle to keep entities fresh. In cloud mode MQTT drives
+        # updates, so only the initial fetch is needed.
+        if self.connection.value != 0 or (update_count == 0 and not self.online):
             json = await self.httpGet("properties/report")
             await self.mqttProperties(json)
 

--- a/custom_components/zendure_ha/select.py
+++ b/custom_components/zendure_ha/select.py
@@ -103,7 +103,7 @@ class ZendureRestoreSelect(ZendureSelect, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-        if state := await self.async_get_last_state():
+        if (state := await self.async_get_last_state()) and state.state in self._attr_options:
             self._attr_current_option = state.state
         else:
             self._attr_current_option = self._attr_options[0]

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "Gerät ist bereits konfiguriert",
-      "reconfigure_successful": "Neukonfiguration erfolgreich"
+      "reconfigure_successful": "Neukonfiguration erfolgreich",
+      "no_devices_configured": "Keine Geräte übrig. Füge mindestens ein Gerät hinzu, bevor du speicherst."
     },
     "error": {
       "cannot_connect": "Die Zendure-API ist nicht erreichbar. Prüfe deine Internetverbindung und versuche es erneut.",
@@ -10,11 +11,23 @@
       "api_rejected": "Zendure hat die Anfrage abgelehnt: {detail}",
       "no_devices": "Token akzeptiert, aber es wurden keine Geräte für dieses Konto gefunden. Stelle sicher, dass du das Zendure-Konto verwendest, bei dem das Gerät registriert ist, sowie die richtige Region.",
       "no_mqtt": "Token akzeptiert, aber es wurde kein MQTT-Server zurückgegeben. Aktiviere lokales oder Cloud-MQTT für dieses Konto in der Zendure-App.",
+      "cannot_connect_local": "Das Gerät konnte im Netzwerk nicht erreicht werden: {detail}. Prüfe die IP-Adresse, stelle sicher, dass sich das Gerät im selben Netzwerk befindet, und dass HEMS in der Zendure-App deaktiviert ist.",
+      "no_local_report": "Das Gerät hat geantwortet, aber keinen gültigen Zen-SDK-Bericht zurückgegeben. Stelle sicher, dass HEMS in der Zendure-App deaktiviert ist.",
+      "unsupported_model": "Dieses Gerätemodell wird für die lokale Einrichtung nicht unterstützt (gemeldet: {detail}). Bitte erstelle ein Issue mit dieser Modellzeichenkette, damit sie hinzugefügt werden kann.",
+      "duplicate_device": "Dieses Gerät ({detail}) wurde bereits hinzugefügt.",
       "invalid_auth": "Ungültige Authentifizierung",
       "unknown": "Unerwarteter Fehler"
     },
     "step": {
       "user": {
+        "title": "Zendure-Einrichtung",
+        "description": "Wähle, wie du dich verbinden möchtest. Cloud verwendet dein Zendure-Konto-Token für die Kommunikation mit deinen Geräten, die Verbindung läuft über die Cloud (Zendure-Server). Lokal (ohne Cloud) spricht direkt mit einem Zen-SDK-fähigen Gerät in deinem Netzwerk.",
+        "menu_options": {
+          "cloud": "Cloud (Zendure-Konto-Token)",
+          "localsdk": "Lokal, ohne Cloud (Zen-SDK-Gerät)"
+        }
+      },
+      "cloud": {
         "data": {
           "token": "Zendure Token",
           "p1meter": "P1 Sensor für Smart Matching",
@@ -23,6 +36,54 @@
           "auto_mqtt_user": "MQTT-Benutzer automatisch verwalten",
           "wifissid": "WLAN SSID",
           "wifipsw": "Wifi Passwort"
+        }
+      },
+      "localsdk": {
+        "title": "Lokales Gerät hinzufügen (ohne Cloud)",
+        "description": "Verbinde dich direkt mit einem Zen-SDK-fähigen Gerät (SolarFlow 800/1600/2400/4000) über dein lokales Netzwerk. Deaktiviere zunächst HEMS in der Zendure-App. Die IP wird sofort nach dem Absenden überprüft.",
+        "data": {
+          "device_ip": "Geräte-IP-Adresse",
+          "device_name": "Gerätename (optional)"
+        }
+      },
+      "localsdk_menu": {
+        "title": "Lokale Geräte",
+        "description": "{count} Gerät(e) hinzugefügt: {devices}. Füge ein weiteres Gerät hinzu oder schließe die Einrichtung ab.",
+        "menu_options": {
+          "localsdk": "Weiteres Gerät hinzufügen",
+          "localsdk_settings": "Abschließen und P1-Zähler festlegen"
+        }
+      },
+      "localsdk_settings": {
+        "title": "Einstellungen für Smart Matching",
+        "description": "Diese Einstellungen gelten für alle lokalen Geräte, die von dieser Integration verwaltet werden.",
+        "data": {
+          "p1meter": "P1 Sensor für Smart Matching",
+          "mqttlog": "Kommunikation loggen"
+        }
+      },
+      "reconfigure_local": {
+        "title": "Lokale Geräte verwalten",
+        "description": "{count} Gerät(e) konfiguriert: {devices}. Füge ein Gerät hinzu oder entferne eines, und speichere dann, um neu zu laden.",
+        "menu_options": {
+          "reconfig_add": "Gerät hinzufügen",
+          "reconfig_remove": "Gerät entfernen",
+          "reconfig_save": "Speichern und neu laden"
+        }
+      },
+      "reconfig_add": {
+        "title": "Lokales Gerät hinzufügen (ohne Cloud)",
+        "description": "Deaktiviere zunächst HEMS in der Zendure-App. Die IP wird sofort nach dem Absenden überprüft.",
+        "data": {
+          "device_ip": "Geräte-IP-Adresse",
+          "device_name": "Gerätename (optional)"
+        }
+      },
+      "reconfig_remove": {
+        "title": "Lokale Geräte entfernen",
+        "description": "Wähle die zu entfernenden Geräte aus.",
+        "data": {
+          "remove": "Zu entfernende Geräte"
         }
       },
       "reconfigure": {
@@ -415,7 +476,8 @@
         "name": "Verbindungsart",
         "state": {
           "local": "Lokal",
-          "cloud": "Cloud"
+          "cloud": "Cloud",
+          "zenSDK": "Zen SDK (lokal)"
         }
       },
       "ble_adapter": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "reconfigure_successful": "Reconfiguration successful",
+      "no_devices_configured": "No devices left. Add at least one device before saving."
     },
     "error": {
       "cannot_connect": "Could not reach the Zendure API. Check your internet connection and try again.",
@@ -10,11 +11,23 @@
       "api_rejected": "Zendure rejected the request: {detail}",
       "no_devices": "Token accepted, but no devices were found on this account. Make sure you use the Zendure account the device is registered to, and the correct region.",
       "no_mqtt": "Token accepted, but no MQTT server was returned. Enable local or cloud MQTT for this account in the Zendure app.",
+      "cannot_connect_local": "Could not reach the device on your network: {detail}. Check the IP address, make sure the device is on the same network, and that HEMS is disabled in the Zendure app.",
+      "no_local_report": "The device answered but did not return a valid Zen SDK report. Make sure HEMS is disabled in the Zendure app.",
+      "unsupported_model": "This device model is not supported for local setup (reported: {detail}). Please open an issue with this model string so it can be added.",
+      "duplicate_device": "This device ({detail}) has already been added.",
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error"
     },
     "step": {
       "user": {
+        "title": "Zendure setup",
+        "description": "Choose how to connect. Cloud uses your Zendure account token to communicate with your devices, with the connection running through the cloud (Zendure servers). Local (no cloud) talks directly to a Zen SDK capable device on your network.",
+        "menu_options": {
+          "cloud": "Cloud (Zendure account token)",
+          "localsdk": "Local, no cloud (Zen SDK device)"
+        }
+      },
+      "cloud": {
         "data": {
           "token": "Zendure Token",
           "p1meter": "P1 Sensor for smart matching",
@@ -23,6 +36,30 @@
           "auto_mqtt_user": "Automatically manage MQTT users",
           "wifissid": "Wifi SSID",
           "wifipsw": "Wifi Password"
+        }
+      },
+      "localsdk": {
+        "title": "Add a local device (no cloud)",
+        "description": "Connect directly to a Zen SDK capable device (SolarFlow 800/1600/2400/4000) over your local network. Disable HEMS in the Zendure app first. The IP is checked as soon as you submit.",
+        "data": {
+          "device_ip": "Device IP address",
+          "device_name": "Device name (optional)"
+        }
+      },
+      "localsdk_menu": {
+        "title": "Local devices",
+        "description": "Added {count} device(s): {devices}. Add another device or finish the setup.",
+        "menu_options": {
+          "localsdk": "Add another device",
+          "localsdk_settings": "Finish and set the P1 meter"
+        }
+      },
+      "localsdk_settings": {
+        "title": "Smart matching settings",
+        "description": "These settings apply to all local devices managed by this integration.",
+        "data": {
+          "p1meter": "P1 Sensor for smart matching",
+          "mqttlog": "Log communication"
         }
       },
       "local": {
@@ -45,6 +82,30 @@
           "auto_mqtt_user": "Automatically manage MQTT users",
           "wifissid": "Wifi SSID",
           "wifipsw": "Wifi Password"
+        }
+      },
+      "reconfigure_local": {
+        "title": "Manage local devices",
+        "description": "{count} device(s) configured: {devices}. Add or remove a device, then save to reload.",
+        "menu_options": {
+          "reconfig_add": "Add a device",
+          "reconfig_remove": "Remove a device",
+          "reconfig_save": "Save and reload"
+        }
+      },
+      "reconfig_add": {
+        "title": "Add a local device (no cloud)",
+        "description": "Disable HEMS in the Zendure app first. The IP is checked as soon as you submit.",
+        "data": {
+          "device_ip": "Device IP address",
+          "device_name": "Device name (optional)"
+        }
+      },
+      "reconfig_remove": {
+        "title": "Remove local devices",
+        "description": "Select the devices to remove.",
+        "data": {
+          "remove": "Devices to remove"
         }
       }
     }
@@ -426,7 +487,8 @@
         "name": "Connection Mode",
         "state": {
           "local": "Local",
-          "cloud": "Cloud"
+          "cloud": "Cloud",
+          "zenSDK": "Zen SDK (local)"
         }
       },
       "ble_adapter": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "L'appareil est déjà configuré",
-      "reconfigure_successful": "Reconfiguration réussie"
+      "reconfigure_successful": "Reconfiguration réussie",
+      "no_devices_configured": "Aucun appareil restant. Ajoutez au moins un appareil avant d'enregistrer."
     },
     "error": {
       "cannot_connect": "Impossible de joindre l'API Zendure. Vérifiez votre connexion Internet et réessayez.",
@@ -10,21 +11,79 @@
       "api_rejected": "Zendure a rejeté la requête : {detail}",
       "no_devices": "Jeton accepté, mais aucun appareil n'a été trouvé sur ce compte. Assurez-vous d'utiliser le compte Zendure sur lequel l'appareil est enregistré, ainsi que la bonne région.",
       "no_mqtt": "Jeton accepté, mais aucun serveur MQTT n'a été renvoyé. Activez le MQTT local ou cloud pour ce compte dans l'application Zendure.",
+      "cannot_connect_local": "Impossible de joindre l'appareil sur votre réseau : {detail}. Vérifiez l'adresse IP, assurez-vous que l'appareil est sur le même réseau, et que HEMS est désactivé dans l'application Zendure.",
+      "no_local_report": "L'appareil a répondu mais n'a pas renvoyé un rapport Zen SDK valide. Assurez-vous que HEMS est désactivé dans l'application Zendure.",
+      "unsupported_model": "Ce modèle d'appareil n'est pas pris en charge pour la configuration locale (signalé : {detail}). Veuillez ouvrir un ticket avec cette chaîne de modèle afin qu'il puisse être ajouté.",
+      "duplicate_device": "Cet appareil ({detail}) a déjà été ajouté.",
       "invalid_auth": "Authentification invalide",
       "unknown": "Erreur inattendue"
     },
     "step": {
       "user": {
+        "title": "Configuration Zendure",
+        "description": "Choisissez comment vous connecter. Cloud utilise le jeton de votre compte Zendure pour communiquer avec vos appareils, la connexion passe par le cloud (serveurs Zendure). Local (sans cloud) communique directement avec un appareil compatible Zen SDK sur votre réseau.",
+        "menu_options": {
+          "cloud": "Cloud (jeton de compte Zendure)",
+          "localsdk": "Local, sans cloud (appareil Zen SDK)"
+        }
+      },
+      "cloud": {
         "data": {
           "token": "Clé cloud d'autorisation Zendure",
-          "username": "Nom d'utilisateur Zendure",
-          "password": "Mot de passe Zendure",
           "p1meter": "Capteur P1 pour le couplage intelligent",
           "mqttlog": "Journaliser la communication MQTT",
           "mqttlocal": "Utiliser MQTT local",
           "auto_mqtt_user": "Gérer automatiquement les utilisateurs MQTT",
           "wifissid": "SSID Wi-Fi",
           "wifipsw": "Mot de passe Wi-Fi"
+        }
+      },
+      "localsdk": {
+        "title": "Ajouter un appareil local (sans cloud)",
+        "description": "Connectez-vous directement à un appareil compatible Zen SDK (SolarFlow 800/1600/2400/4000) sur votre réseau local. Désactivez d'abord HEMS dans l'application Zendure. L'IP est vérifiée dès la soumission.",
+        "data": {
+          "device_ip": "Adresse IP de l'appareil",
+          "device_name": "Nom de l'appareil (optionnel)"
+        }
+      },
+      "localsdk_menu": {
+        "title": "Appareils locaux",
+        "description": "{count} appareil(s) ajouté(s) : {devices}. Ajoutez un autre appareil ou terminez la configuration.",
+        "menu_options": {
+          "localsdk": "Ajouter un autre appareil",
+          "localsdk_settings": "Terminer et définir le capteur P1"
+        }
+      },
+      "localsdk_settings": {
+        "title": "Paramètres de couplage intelligent",
+        "description": "Ces paramètres s'appliquent à tous les appareils locaux gérés par cette intégration.",
+        "data": {
+          "p1meter": "Capteur P1 pour le couplage intelligent",
+          "mqttlog": "Journaliser la communication"
+        }
+      },
+      "reconfigure_local": {
+        "title": "Gérer les appareils locaux",
+        "description": "{count} appareil(s) configuré(s) : {devices}. Ajoutez ou supprimez un appareil, puis enregistrez pour recharger.",
+        "menu_options": {
+          "reconfig_add": "Ajouter un appareil",
+          "reconfig_remove": "Supprimer un appareil",
+          "reconfig_save": "Enregistrer et recharger"
+        }
+      },
+      "reconfig_add": {
+        "title": "Ajouter un appareil local (sans cloud)",
+        "description": "Désactivez d'abord HEMS dans l'application Zendure. L'IP est vérifiée dès la soumission.",
+        "data": {
+          "device_ip": "Adresse IP de l'appareil",
+          "device_name": "Nom de l'appareil (optionnel)"
+        }
+      },
+      "reconfig_remove": {
+        "title": "Supprimer des appareils locaux",
+        "description": "Sélectionnez les appareils à supprimer.",
+        "data": {
+          "remove": "Appareils à supprimer"
         }
       },
       "local": {
@@ -387,7 +446,8 @@
         "name": "Mode de connexion",
         "state": {
           "local": "Local",
-          "cloud": "Cloud"
+          "cloud": "Cloud",
+          "zenSDK": "Zen SDK (local)"
         }
       },
       "ble_adapter": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -2,7 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "Apparaat is al geconfigureerd",
-      "reconfigure_successful": "Hergroepering geslaagd"
+      "reconfigure_successful": "Hergroepering geslaagd",
+      "no_devices_configured": "Geen apparaten meer over. Voeg minstens één apparaat toe voordat je opslaat."
     },
     "error": {
       "cannot_connect": "De Zendure-API is niet bereikbaar. Controleer je internetverbinding en probeer het opnieuw.",
@@ -10,20 +11,79 @@
       "api_rejected": "Zendure heeft het verzoek geweigerd: {detail}",
       "no_devices": "Token geaccepteerd, maar er zijn geen apparaten gevonden op dit account. Zorg dat je het Zendure-account gebruikt waarop het apparaat is geregistreerd, en de juiste regio.",
       "no_mqtt": "Token geaccepteerd, maar er is geen MQTT-server teruggegeven. Schakel lokale of cloud-MQTT in voor dit account in de Zendure-app.",
+      "cannot_connect_local": "Het apparaat op je netwerk kon niet worden bereikt: {detail}. Controleer het IP-adres, zorg dat het apparaat op hetzelfde netwerk zit, en dat HEMS is uitgeschakeld in de Zendure-app.",
+      "no_local_report": "Het apparaat antwoordde, maar gaf geen geldig Zen SDK-rapport terug. Zorg dat HEMS is uitgeschakeld in de Zendure-app.",
+      "unsupported_model": "Dit apparaatmodel wordt niet ondersteund voor lokale installatie (gemeld: {detail}). Open een issue met deze modeltekst, zodat het toegevoegd kan worden.",
+      "duplicate_device": "Dit apparaat ({detail}) is al toegevoegd.",
       "invalid_auth": "Ongeldige authenticatie",
       "unknown": "Onverwachte fout"
     },
     "step": {
       "user": {
+        "title": "Zendure instellen",
+        "description": "Kies hoe je wilt verbinden. Cloud gebruikt je Zendure-token voor de communicatie met je apparaten, de verbinding loopt via de cloud (Zendure-servers). Lokaal (zonder cloud) communiceert rechtstreeks met een Zen SDK-geschikt apparaat op je netwerk.",
+        "menu_options": {
+          "cloud": "Cloud (Zendure accounttoken)",
+          "localsdk": "Lokaal, zonder cloud (Zen SDK-apparaat)"
+        }
+      },
+      "cloud": {
         "data": {
-          "username": "Zendure Gebruikersnaam",
-          "password": "Zendure Wachtwoord",
+          "token": "Zendure Token",
           "p1meter": "P1 Sensor voor slimme matching",
           "mqttlog": "MQTT-Communicatie loggen",
           "mqttlocal": "Lokale MQTT gebruiken",
           "auto_mqtt_user": "MQTT-gebruikers automatisch beheren",
           "wifissid": "Wifi SSID",
           "wifipsw": "Wifi Wachtwoord"
+        }
+      },
+      "localsdk": {
+        "title": "Lokaal apparaat toevoegen (zonder cloud)",
+        "description": "Maak rechtstreeks verbinding met een Zen SDK-geschikt apparaat (SolarFlow 800/1600/2400/4000) via je lokale netwerk. Schakel eerst HEMS uit in de Zendure-app. Het IP-adres wordt direct na het versturen gecontroleerd.",
+        "data": {
+          "device_ip": "IP-adres apparaat",
+          "device_name": "Apparaatnaam (optioneel)"
+        }
+      },
+      "localsdk_menu": {
+        "title": "Lokale apparaten",
+        "description": "{count} apparaat/apparaten toegevoegd: {devices}. Voeg nog een apparaat toe of rond de installatie af.",
+        "menu_options": {
+          "localsdk": "Nog een apparaat toevoegen",
+          "localsdk_settings": "Afronden en P1-meter instellen"
+        }
+      },
+      "localsdk_settings": {
+        "title": "Instellingen voor slimme matching",
+        "description": "Deze instellingen gelden voor alle lokale apparaten die door deze integratie worden beheerd.",
+        "data": {
+          "p1meter": "P1 Sensor voor slimme matching",
+          "mqttlog": "Communicatie loggen"
+        }
+      },
+      "reconfigure_local": {
+        "title": "Lokale apparaten beheren",
+        "description": "{count} apparaat/apparaten geconfigureerd: {devices}. Voeg een apparaat toe of verwijder er een, en sla daarna op om opnieuw te laden.",
+        "menu_options": {
+          "reconfig_add": "Apparaat toevoegen",
+          "reconfig_remove": "Apparaat verwijderen",
+          "reconfig_save": "Opslaan en herladen"
+        }
+      },
+      "reconfig_add": {
+        "title": "Lokaal apparaat toevoegen (zonder cloud)",
+        "description": "Schakel eerst HEMS uit in de Zendure-app. Het IP-adres wordt direct na het versturen gecontroleerd.",
+        "data": {
+          "device_ip": "IP-adres apparaat",
+          "device_name": "Apparaatnaam (optioneel)"
+        }
+      },
+      "reconfig_remove": {
+        "title": "Lokale apparaten verwijderen",
+        "description": "Selecteer de apparaten om te verwijderen.",
+        "data": {
+          "remove": "Te verwijderen apparaten"
         }
       },
       "local": {
@@ -339,7 +399,8 @@
         "name": "Verbindingsmodus",
         "state": {
           "local": "Lokaal",
-          "cloud": "Cloud"
+          "cloud": "Cloud",
+          "zenSDK": "Zen SDK (lokaal)"
         }
       },
       "ble_adapter": {

--- a/custom_components/zendure_ha/translations/pl.json
+++ b/custom_components/zendure_ha/translations/pl.json
@@ -2,15 +2,28 @@
   "config": {
     "abort": {
       "already_configured": "Urządzenie jest już skonfigurowane",
-      "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie"
+      "reconfigure_successful": "Rekonfiguracja zakończona pomyślnie",
+      "no_devices_configured": "Nie pozostały żadne urządzenia. Dodaj co najmniej jedno urządzenie przed zapisaniem."
     },
     "error": {
       "cannot_connect": "Nie udało się połączyć",
+      "cannot_connect_local": "Nie można połączyć się z urządzeniem w sieci: {detail}. Sprawdź adres IP, upewnij się, że urządzenie jest w tej samej sieci, oraz że HEMS jest wyłączony w aplikacji Zendure.",
+      "no_local_report": "Urządzenie odpowiedziało, ale nie zwróciło prawidłowego raportu Zen SDK. Upewnij się, że HEMS jest wyłączony w aplikacji Zendure.",
+      "unsupported_model": "Ten model urządzenia nie jest obsługiwany w konfiguracji lokalnej (zgłoszono: {detail}). Zgłoś ten ciąg modelu jako issue, aby mógł zostać dodany.",
+      "duplicate_device": "To urządzenie ({detail}) zostało już dodane.",
       "invalid_auth": "Nieprawidłowe dane uwierzytelniające",
       "unknown": "Nieoczekiwany błąd"
     },
     "step": {
       "user": {
+        "title": "Konfiguracja Zendure",
+        "description": "Wybierz sposób połączenia. Chmura używa tokenu Twojego konta Zendure do komunikacji z Twoimi urządzeniami, połączenie przebiega przez chmurę (serwery Zendure). Lokalnie (bez chmury) łączy się bezpośrednio z urządzeniem obsługującym Zen SDK w Twojej sieci.",
+        "menu_options": {
+          "cloud": "Chmura (token konta Zendure)",
+          "localsdk": "Lokalnie, bez chmury (urządzenie Zen SDK)"
+        }
+      },
+      "cloud": {
         "data": {
           "token": "Token Zendure",
           "p1meter": "Czujnik P1 do inteligentnego dopasowania",
@@ -19,6 +32,54 @@
           "auto_mqtt_user": "Automatycznie zarządzaj użytkownikami MQTT",
           "wifissid": "SSID sieci Wi-Fi",
           "wifipsw": "Hasło Wi-Fi"
+        }
+      },
+      "localsdk": {
+        "title": "Dodaj urządzenie lokalne (bez chmury)",
+        "description": "Połącz się bezpośrednio z urządzeniem obsługującym Zen SDK (SolarFlow 800/1600/2400/4000) w Twojej sieci lokalnej. Najpierw wyłącz HEMS w aplikacji Zendure. Adres IP jest sprawdzany zaraz po przesłaniu.",
+        "data": {
+          "device_ip": "Adres IP urządzenia",
+          "device_name": "Nazwa urządzenia (opcjonalnie)"
+        }
+      },
+      "localsdk_menu": {
+        "title": "Urządzenia lokalne",
+        "description": "Dodano {count} urządzeń: {devices}. Dodaj kolejne urządzenie lub zakończ konfigurację.",
+        "menu_options": {
+          "localsdk": "Dodaj kolejne urządzenie",
+          "localsdk_settings": "Zakończ i ustaw czujnik P1"
+        }
+      },
+      "localsdk_settings": {
+        "title": "Ustawienia inteligentnego dopasowania",
+        "description": "Te ustawienia dotyczą wszystkich urządzeń lokalnych zarządzanych przez tę integrację.",
+        "data": {
+          "p1meter": "Czujnik P1 do inteligentnego dopasowania",
+          "mqttlog": "Rejestruj komunikację"
+        }
+      },
+      "reconfigure_local": {
+        "title": "Zarządzaj urządzeniami lokalnymi",
+        "description": "Skonfigurowano {count} urządzeń: {devices}. Dodaj lub usuń urządzenie, a następnie zapisz, aby przeładować.",
+        "menu_options": {
+          "reconfig_add": "Dodaj urządzenie",
+          "reconfig_remove": "Usuń urządzenie",
+          "reconfig_save": "Zapisz i przeładuj"
+        }
+      },
+      "reconfig_add": {
+        "title": "Dodaj urządzenie lokalne (bez chmury)",
+        "description": "Najpierw wyłącz HEMS w aplikacji Zendure. Adres IP jest sprawdzany zaraz po przesłaniu.",
+        "data": {
+          "device_ip": "Adres IP urządzenia",
+          "device_name": "Nazwa urządzenia (opcjonalnie)"
+        }
+      },
+      "reconfig_remove": {
+        "title": "Usuń urządzenia lokalne",
+        "description": "Wybierz urządzenia do usunięcia.",
+        "data": {
+          "remove": "Urządzenia do usunięcia"
         }
       },
       "local": {
@@ -407,7 +468,8 @@
         "name": "Tryb połączenia",
         "state": {
           "local": "Lokalny",
-          "cloud": "Chmura"
+          "cloud": "Chmura",
+          "zenSDK": "Zen SDK (lokalnie)"
         }
       },
       "ble_adapter": {


### PR DESCRIPTION
### Summary

Adds a local (cloud-free) onboarding option to the config flow that talks directly to ZenSDK-capable devices over their on-device HTTP API, no Zendure account token needed. Requires knowing the device's IP and assigning it a static address.

This works around the "no device found" issue reported in #1502 (e.g. affects the SolarFlow 4000 Mix, which the cloud API doesn't seem to return). But can also be used by those that want a true local setup, that does not require a cloud based MQTT connection.

Devices onboarded locally behave identically to cloud-onboarded ones, same entities, same manager logic.

### Detailed changes

- **`config_flow.py`**: new cloud/local pick menu, plus an add device wizard for local devices. Each device is validated via its `/properties/report` endpoint, with the model auto-detected from the reported product string. Reconfigure supports adding/removing devices later.
- **`api.py`**: in local mode, `Connect()` synthesizes the device list from config instead of hitting the cloud API and skips cloud MQTT setup; `localDeviceList()` builds one entry per configured device; `testLocalDevice()` validates a device and returns `(sn, product)`. Also registers the `solarFlow4000MixAC+` product alias to `SolarFlow4000AC_Plus`.
- **`device.py`**: local devices default to (and are locked to) the ZenSDK connection, and poll the local report every cycle since there's no MQTT push.
- `Api.devices`: is now cleared on unload and on device removal, so a removed device doesn't reappear.

### Localization
I manually worked on Dutch and English, however an LLM was used to translate to other languages. Would be appreciated if someone could check those.

### Test plan
- [X] Add a local device via the new config flow menu and confirm it validates and creates entities
- [ ] Confirm a cloud-onboarded setup still works unchanged
- [X] Remove a local device via reconfigure and confirm it doesn't reappear on reload
- [X] Confirm the last device on a local-only entry can't be removed (only the whole entry)

Unfortunately I cannot easily test if cloud-onboarded devices/setup still works as expected, as I don't have any devices that work via that method. Perhaps someone else could validate, but the code path is basically unaffected so I don't expect any issues.

Please let me know what you think of this PR, I'm happy to work on details where required.