### PR TITLE
Debounce smartMode/acMode re-assertion on zenSDK limit writes

### DIFF
--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -71,3 +71,5 @@ class SmartMode:
 
     POWER_START = 50  # Minimum Power (W) for starting a device
     POWER_TOLERANCE = 5  # Device-level power tolerance (W) before updating
+
+    MODE_REASSERT_INTERVAL = timedelta(seconds=30)  # Min interval between forced smartMode/acMode re-assertions on unchanged direction

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -724,6 +724,8 @@ class ZendureZenSdk(ZendureDevice):
         super().__init__(hass, deviceId, name, model, definition, parent)
         self.connection = ZendureRestoreSelect(self, "connection", {0: "cloud", 2: "zenSDK"}, self.mqttSelect, 0)
         self.httpid = 0
+        self._modeAsserted: tuple[int, int] | None = None
+        self._modeAssertedAt: datetime = datetime.min
 
     async def mqttSelect(self, select: Any, _value: Any) -> None:
         from .api import Api
@@ -745,10 +747,9 @@ class ZendureZenSdk(ZendureDevice):
             _LOGGER.error("Entity %s has no translation_key, cannot write property %s", entity.name, self.name)
             return
 
-        # Route limit writes through the power routines so they send the full command
-        # (smartMode/acMode), exactly like the manager does. A bare outputLimit/inputLimit
-        # property write is silently ignored when the device has dropped out of smart mode
-        # (observed on SolarFlow 2400 Pro at 100% SoC, see #1505).
+        # Route limit writes through the power routines so they can (re-)assert
+        # smartMode/acMode when needed, exactly like the manager does. See
+        # ZendureZenSdk._sendPower for why that assertion is debounced.
         if entity.propertyName == "outputLimit":
             await self.discharge(value)
         elif entity.propertyName == "inputLimit":
@@ -778,7 +779,8 @@ class ZendureZenSdk(ZendureDevice):
         if power == -SmartMode.POWER_START and self.limitInput.asInt >= SmartMode.POWER_START and self.homeInput.asInt == 0:
             power = -min(self.limitInput.asInt + 4, 2 * SmartMode.POWER_START)
             _LOGGER.info("Power charge kickstart %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 1, "outputLimit": 0, "inputLimit": -power}})
+        smartMode = 0 if power == 0 and self.pwr_offgrid == 0 else 1
+        await self._sendPower(smartMode, 1, 0, -power)
         return power
 
     async def discharge(self, power: int) -> int:
@@ -786,12 +788,25 @@ class ZendureZenSdk(ZendureDevice):
         if power == SmartMode.POWER_START and self.limitOutput.asInt >= SmartMode.POWER_START and self.homeOutput.asInt == 0:
             power = min(self.limitOutput.asInt + 4, 2 * SmartMode.POWER_START)
             _LOGGER.info("Power discharge kickstart %s => %s", self.name, power)
-        await self.doCommand({"properties": {"smartMode": 0 if power == 0 and self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": power, "inputLimit": 0}})
+        smartMode = 0 if power == 0 and self.pwr_offgrid == 0 else 1
+        await self._sendPower(smartMode, 2, power, 0)
         return power
 
     async def power_off(self) -> None:
         """Set the power off."""
-        await self.doCommand({"properties": {"smartMode": 0 if self.pwr_offgrid == 0 else 1, "acMode": 2, "outputLimit": 0, "inputLimit": 0}})
+        smartMode = 0 if self.pwr_offgrid == 0 else 1
+        await self._sendPower(smartMode, 2, 0, 0)
+
+    async def _sendPower(self, smartMode: int, acMode: int, outputLimit: int, inputLimit: int) -> None:
+        """Send a limit write, (re-)asserting smartMode/acMode only on direction change or after MODE_REASSERT_INTERVAL (#1505 vs #1521)."""
+        props: dict[str, int] = {"outputLimit": outputLimit, "inputLimit": inputLimit}
+        now = datetime.now()
+        if (smartMode, acMode) != self._modeAsserted or now - self._modeAssertedAt > SmartMode.MODE_REASSERT_INTERVAL:
+            props["smartMode"] = smartMode
+            props["acMode"] = acMode
+            self._modeAsserted = (smartMode, acMode)
+            self._modeAssertedAt = now
+        await self.doCommand({"properties": props})
 
     async def doCommand(self, command: Any) -> None:
         if self.connection.value != 0:


### PR DESCRIPTION
## Problem

PR #1507 routed every `number.output_limit` / `number.input_limit` write through `discharge()`/`charge()`, which unconditionally sends the full command (`smartMode` + `acMode`) alongside the limit. That fixed the original problem — a bare property write is silently ignored once the device has dropped out of smart mode (#1505) — but it now forces a `smartMode`/`acMode` re-assertion on **every single write**, including the manager's own alternating charge/discharge dispatch and repeated writes from an external automation, even when the direction hasn't actually changed.

Reported in #1521: after updating to 1.4.3, "the smart mode alternates after every mqtt command" — `smartMode` flips 0→1→0 and `acMode` bounces input/output on every command, batteries drop to Standby. Multiple users confirmed, and one traced it to the exact commit (`f4e2267`, i.e. #1507).

## Fix

Only include `smartMode`/`acMode` in the outgoing command when:
- the requested direction (`acMode`) differs from the last one this device instance asserted, or
- `MODE_REASSERT_INTERVAL` (30s) has elapsed since the last assertion.

Otherwise only the bare `outputLimit`/`inputLimit` is sent — matching pre-1.4.3 behavior for steady-state writes. The periodic re-assertion (rather than "only on change") is kept so a silent smart-mode drop still self-heals within 30s without requiring an explicit direction change first, preserving the #1505 fix.

`charge()`, `discharge()`, and `power_off()` (used by both `entityWrite` and the manager's `power_charge`/`power_discharge` dispatch) now share this logic via a new `ZendureZenSdk._sendPower` helper, so manager-driven and externally-driven writes stay consistent about what mode was last asserted.

## Testing

- Verified `device.py`/`const.py` parse cleanly.
- Traced the call paths for `entityWrite` (external/automation writes) and `manager.power_charge`/`power_discharge` (built-in smart dispatch) to confirm both route through the same debounced `_sendPower`, so the fix applies uniformly regardless of the caller.
- No existing test suite in the repo to run against.

Fixes #1521

## Related (same 1.4.3 symptom cluster, not fixed by this PR)

- #1525 — SF2400 AC rapidly flip-flops charge/discharge in smart mode. This is the manager's own dispatch (`power_charge`/`power_discharge`) legitimately alternating direction, so the debounce here doesn't suppress it — looks like a separate hysteresis issue in `manager.py`'s dispatcher, not caused by #1507.
- #1522 / #1536 — discharge/charge behavior around low-production periods; also traced by a commenter to a possible missing dead-zone in `manager.py`'s dispatcher rather than the `entityWrite` path this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
