### PR TITLE
Fix output limit not accounting for the solar pass-through

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -473,20 +473,22 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.availableKwh.update_value(availableKwh)
         self.globalSoc.update_value((totalStoredkWh / onlinekWh * 100) if onlinekWh > 0 else 0)
 
-        # Bypass production of SOCFULL devices is non-dispatchable: it keeps flowing
-        # to the home regardless of the distribution (power_charge skips devices with
-        # byPass > 0). Remove it from the dispatchable setpoint. Because the per-device
-        # bypass is capped at its homeOutput contribution, this subtraction can never
-        # push the setpoint below "p1 - real charge credits": with no device charging
-        # and p1 >= 0, the result stays >= 0 — the #1151 guarantee holds structurally.
-        setpoint -= self.discharge_bypass
+        # Bypass production of SOCFULL devices is non-dispatchable: it keeps flowing to the
+        # home regardless of the distribution (power_charge skips devices with byPass > 0), so
+        # it must not count as headroom when deciding whether to charge. It is however part of
+        # the home output the devices are asked to deliver: outputLimit is an absolute output
+        # target and not a delta on top of the bypass, so the distribution keeps the full
+        # setpoint. Because the per-device bypass is capped at its homeOutput contribution,
+        # dispatchable can never drop below "p1 - real charge credits": with no device charging
+        # and p1 >= 0 it stays >= 0 — the #1151 guarantee holds structurally.
+        dispatchable = setpoint - self.discharge_bypass
 
         # Update power distribution.
-        _LOGGER.info("P1 ======> p1:%s isFast:%s, setpoint:%sW stored:%sW", p1, isFast, setpoint, self.produced)
+        _LOGGER.info("P1 ======> p1:%s isFast:%s, setpoint:%sW dispatchable:%sW stored:%sW", p1, isFast, setpoint, dispatchable, self.produced)
         match self.operation:
             case ManagerMode.MATCHING:
-                if setpoint < 0:
-                    await self.power_charge(setpoint, time)
+                if dispatchable < 0:
+                    await self.power_charge(dispatchable, time)
                 else:
                     await self.power_discharge(setpoint)
 
@@ -497,10 +499,10 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             case ManagerMode.MATCHING_CHARGE | ManagerMode.STORE_SOLAR:
                 # Allow discharge of produced power in MATCHING_CHARGE-Mode, otherwise only charge
                 # d.pwr_produced is negative, but self.produced is positive
-                if setpoint > 0 and self.produced > SmartMode.POWER_START and self.operation == ManagerMode.MATCHING_CHARGE:
+                if dispatchable > 0 and self.produced > SmartMode.POWER_START and self.operation == ManagerMode.MATCHING_CHARGE:
                     await self.power_discharge(min(self.produced, setpoint))
                 else:
-                    await self.power_charge(min(0, setpoint), time)
+                    await self.power_charge(min(0, dispatchable), time)
 
             case ManagerMode.MANUAL:
                 # Manual power into or from home


### PR DESCRIPTION
### Summary
I run a SolarFlow 4000 Mix AC+ on its own circuit with the panels feeding its AC PV input. Once the battery reaches its target state of charge the device passes that solar straight through to the home (and any leftovers on to the grid). In that state, with no leftovers going to the grid, I kept seeing the grid supply power the battery should have been covering with ease.

One evening: 1400 W of solar going through, 350 W coming off the grid, the battery at 0 W. The manager had worked out the 1750 W household load correctly, yet sent the device an output limit of 350 W, well below the 1400 W it was already passing through. A device in bypass does not limit its solar pass-through, so it simply held at 1400 W and the battery never started discharging.

The pass-through is subtracted from the setpoint before the setpoint is distributed, but the device reads the limit it receives as its total output to the home, not as an addition on top of the bypass. Every commanded limit is therefore short by exactly the pass-through power. Once the grid is supplying more than the device is passing through, the battery does start, yet still under-delivers by that same amount: at a 4000 W load the device was asked for 2600 W and the battery discharged 1200 W where 2600 W was needed.

### Detailed Changes

**`manager.py`**: `powerChanged()` no longer subtracts `discharge_bypass` from the setpoint it distributes. The subtraction moved into a separate `dispatchable` value, which now drives the charge/discharge decision and is what `power_charge()` receives; `power_discharge()` gets the full home output target that `outputLimit` expects. Both figures are logged, since they differ only during bypass.

Smart discharging and smart charging had the same issue and are fixed by the same change. The value reaching the charge side is unchanged, so the fixes made in #1151 are unaffected: the subtraction does belong there, because pass-through power cannot be dialled back and must not be read as room to charge.

### Tests
Observed and tested on my own SolarFlow 4000 Mix AC+, which is usable in this integration thanks to my earlier PRs #1528 and #1529. This PR depends on neither and can be merged independently, though I would love some eyes on those two as well.
