### PR TITLE
Add higher fuse group limits for the Mix (4000) series

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -153,7 +153,18 @@ class ZendureDevice(EntityDevice):
         self.socLimit = ZendureSensor(self, "socLimit", state=0)
         self.byPass = ZendureSensor(self, "pass", state=0)
 
-        fuseGroups = {0: "unused", 1: "owncircuit", 2: "group800", 3: "group800_2400", 4: "group1200", 5: "group2000", 6: "group2400", 7: "group3600"}
+        fuseGroups = {
+            0: "unused",
+            1: "owncircuit",
+            2: "group800",
+            3: "group800_2400",
+            4: "group1200",
+            5: "group2000",
+            6: "group2400",
+            7: "group3600",
+            8: "group4000",
+            9: "group5000",
+        }
         self.fuseGroup = ZendureRestoreSelect(self, "fuseGroup", fuseGroups, None)
         self.acMode = ZendureSelect(self, "acMode", {1: "input", 2: "output"}, self.entityWrite, 1)
         self.electricLevel = ZendureSensor(self, "electricLevel", None, "%", "battery", "measurement")

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -193,6 +193,10 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                         fg = FuseGroup(device.name, 2000, -2000)
                     case "group2400":
                         fg = FuseGroup(device.name, 2400, -2400)
+                    case "group4000":
+                        fg = FuseGroup(device.name, 4000, -4000)
+                    case "group5000":
+                        fg = FuseGroup(device.name, 5000, -5000)
                     case "unused":
                         # only switch off, if Manager is used
                         if self.operation != ManagerMode.OFF:
@@ -222,6 +226,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     5: "group2000",
                     6: "group2400",
                     7: "group3600",
+                    8: "group4000",
+                    9: "group5000",
                 }
                 for deviceId, fg in fuseGroups.items():
                     if deviceId != device.deviceId:

--- a/custom_components/zendure_ha/translations/de.json
+++ b/custom_components/zendure_ha/translations/de.json
@@ -402,13 +402,15 @@
         "name": "Geräte-Sicherungsgruppe",
         "state": {
           "unused": "Nicht verwendet, Gerät hat keine Sicherungsgruppe",
-          "owncircuit": "Gerät hat einen eigenen Stromkreis oder eine eigene Phase",
+          "owncircuit": "Gerät hat einen eigenen Stromkreis oder eine eigene Phase, max. 3600 W",
           "group800": "Sicherungsgruppe max. 800 W / 1200W laden",
           "group800_2400": "Sicherungsgruppe max. 800 W / 2400W laden",
           "group1200": "Sicherungsgruppe max. 1200 W",
           "group2000": "Sicherungsgruppe max. 2000 W",
           "group2400": "Sicherungsgruppe max. 2400 W",
-          "group3600": "Sicherungsgruppe max. 3600 W"
+          "group3600": "Sicherungsgruppe max. 3600 W",
+          "group4000": "Sicherungsgruppe max. 4000 W",
+          "group5000": "Sicherungsgruppe max. 5000 W"
         }
       },
       "connection": {

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -413,13 +413,15 @@
         "name": "Device Fuse Group",
         "state": {
           "unused": "Unused, device has No FuseGroup",
-          "owncircuit": "Device has its own circuit or phase",
+          "owncircuit": "Device has its own circuit or phase, max. 3600w",
           "group800": "FuseGroup max. 800w / 1200w charge",
           "group800_2400": "FuseGroup max. 800w / 2400w charge",
           "group1200": "FuseGroup max. 1200w",
           "group2000": "FuseGroup max. 2000w",
           "group2400": "FuseGroup max. 2400w",
-          "group3600": "FuseGroup max. 3600w"
+          "group3600": "FuseGroup max. 3600w",
+          "group4000": "FuseGroup max. 4000w",
+          "group5000": "FuseGroup max. 5000w"
         }
       },
       "connection": {

--- a/custom_components/zendure_ha/translations/fr.json
+++ b/custom_components/zendure_ha/translations/fr.json
@@ -374,13 +374,15 @@
         "name": "groupe de fusible de l'appareil",
         "state": {
           "unused": "Aucun (appareil NON-utilisé en couplage intelligent)",
-          "owncircuit": "L'appareil a son propre circuit ou phase",
+          "owncircuit": "L'appareil a son propre circuit ou phase, max. 3600 W",
           "group800": "groupe de fusible max. 800 W / 1200 W charge",
           "group800_2400": "groupe de fusible max. 800 W / 2400 W charge",
           "group1200": "groupe de fusible max. 1200 W",
           "group2000": "groupe de fusible max. 2000 W",
           "group2400": "groupe de fusible max. 2400 W",
-          "group3600": "groupe de fusible max. 3600 W"
+          "group3600": "groupe de fusible max. 3600 W",
+          "group4000": "groupe de fusible max. 4000 W",
+          "group5000": "groupe de fusible max. 5000 W"
         }
       },
       "connection": {

--- a/custom_components/zendure_ha/translations/nl.json
+++ b/custom_components/zendure_ha/translations/nl.json
@@ -326,13 +326,15 @@
         "name": "Device fusegroup",
         "state": {
           "unused": "Niet gebruikt, apparaat heeft geen zekeringgroep",
-          "owncircuit": "Apparaat is aangesloten op aparte groep of fase",
+          "owncircuit": "Apparaat is aangesloten op aparte groep of fase, max. 3600w",
           "group800": "Zekeringgroep max. 800w / 1200w batterijlading",
           "group800_2400": "Zekeringgroep max. 800w / 2400w batterijlading",
           "group1200": "Zekeringgroep max. 1200w",
           "group2000": "Zekeringgroep max. 2000w",
           "group2400": "Zekeringgroep max. 2400w",
-          "group3600": "Zekeringgroep max. 3600w"
+          "group3600": "Zekeringgroep max. 3600w",
+          "group4000": "Zekeringgroep max. 4000w",
+          "group5000": "Zekeringgroep max. 5000w"
         }
       },
       "connection": {

--- a/custom_components/zendure_ha/translations/pl.json
+++ b/custom_components/zendure_ha/translations/pl.json
@@ -394,13 +394,15 @@
         "name": "Grupa bezpiecznikowa urządzenia",
         "state": {
           "unused": "Nieużywana, urządzenie nie ma grupy bezpiecznikowej",
-          "owncircuit": "Urządzenie ma własny obwód lub fazę",
+          "owncircuit": "Urządzenie ma własny obwód lub fazę, maks. 3600 W",
           "group800": "Grupa bezpiecznikowa maks. 800 W / 1200 W ładowanie",
           "group800_2400": "Grupa bezpiecznikowa maks. 800 W / 2400 W ładowanie",
           "group1200": "Grupa bezpiecznikowa maks. 1200 W",
           "group2000": "Grupa bezpiecznikowa maks. 2000 W",
           "group2400": "Grupa bezpiecznikowa maks. 2400 W",
-          "group3600": "Grupa bezpiecznikowa maks. 3600 W"
+          "group3600": "Grupa bezpiecznikowa maks. 3600 W",
+          "group4000": "Grupa bezpiecznikowa maks. 4000 W",
+          "group5000": "Grupa bezpiecznikowa maks. 5000 W"
         }
       },
       "connection": {


### PR DESCRIPTION
### Summary
My Mix 4000 AC+ sits on its own 32 A circuit with Maximum Inverter Power raised to above 3600 W, yet I never saw it deliver more than about 3600 W. It should manage at least 4000 W or even 5000 W with solar in bypass mode.

The fuse group options stop at 3600 W, and `FuseGroup.discharge_limit()` bounds every device with `min(group rating, device limit)`. With nothing higher to select, the group held the device at 3600 W regardless of its own limit.

### Detailed Changes
**`manager.py`** / **`device.py`**: add 4000 W and 5000 W fuse groups, following the existing options rather than a breaker series. A device stays bounded by its own limit within the group, so the smaller models are unaffected.

`owncircuit` keeps its 3600 W bound, since having its own circuit says nothing about the breaker protecting it. Its description now names that bound (claiming no rating at all is what made the cap hard to find).

### Localization
I have translated Dutch and English manually, all other languages have been translated using LLM assistance.

### Tests
Tested on my own SolarFlow 4000 Mix AC+, which is usable in this integration thanks to my earlier PRs #1528 and #1529. It now reaches 5000 W instead of stopping at 3600 W.

Related to #1555: both that PR and this one were needed before it actually delivered its rated output, but neither depends on the other.