### PR TITLE
Add the SOCFULL bypass back to the discharge command

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -137,6 +137,8 @@ class ZendureDevice(EntityDevice):
         self.maxSolar = 0
         self.pwr_max: int = 0
         self.pwr_produced: int = 0
+        # part of homeOutput the manager removes from its setpoint as non-dispatchable
+        self.pwr_bypass: int = 0
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
         self.exports_bypass: bool = True

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -427,6 +427,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         onlinekWh = 0
 
         for d in self.devices:
+            d.pwr_bypass = 0
             if await d.power_get():
                 # get power production
                 d.pwr_produced = min(0, d.batteryOutput.asInt + d.homeInput.asInt - d.batteryInput.asInt - d.homeOutput.asInt)
@@ -451,7 +452,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     # skew), and subtracting more than was added fabricates a phantom negative
                     # setpoint — the root cause of #1151.
                     if d.state == DeviceState.SOCFULL and d.exports_bypass:
-                        self.discharge_bypass += min(-d.pwr_produced, home)
+                        d.pwr_bypass = min(-d.pwr_produced, home)
+                        self.discharge_bypass += d.pwr_bypass
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced
@@ -593,12 +595,20 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
             await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
 
+        # Bypass already flows to the home and was subtracted from the setpoint, so it is
+        # excluded from the capacities below and added back to the absolute command.
+        dispatch_limit = self.discharge_limit - self.discharge_bypass
+        dispatch_produced = max(0, self.discharge_produced - self.discharge_bypass)
+
         # distribute discharging devices, use produced power first, before adding another device
-        dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0
-        solaronly = self.discharge_produced >= setpoint
-        limit = self.discharge_produced if solaronly else self.discharge_limit
+        dev_start = max(0, setpoint - self.discharge_optimal * 2 - dispatch_produced) if setpoint > SmartMode.POWER_START else 0
+        solaronly = dispatch_produced >= setpoint
+        limit = dispatch_produced if solaronly else dispatch_limit
         setpoint = min(limit, setpoint)
         for i, d in enumerate(sorted(self.discharge, key=lambda d: d.electricLevel.asInt, reverse=False)):
+            headroom = max(0, d.pwr_max - d.pwr_bypass)
+            solar = max(0, -d.pwr_produced - d.pwr_bypass)
+
             # Weight per device: pwr_max * SOC%. Devices with higher SOC get a
             # larger share of the discharge power.
             # Guard against division by zero: discharge_weight can be 0 when all
@@ -612,23 +622,23 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 pwr = int(setpoint / (len(self.discharge) - i))
             else:
                 pwr = 0
-            # SOCFULL devices should only pass through solar, not drain battery
-            if pwr < -d.pwr_produced and d.state == DeviceState.SOCFULL:
-                pwr = -d.pwr_produced
+            # SOCFULL devices should pass through at least their remaining solar
+            if pwr < solar and d.state == DeviceState.SOCFULL:
+                pwr = solar
             self.discharge_weight -= device_weight
 
             # adjust the limit, make sure we have 'enough' power to discharge
-            limit -= -d.pwr_produced if solaronly else d.pwr_max
+            limit -= solar if solaronly else headroom
             if limit < setpoint - pwr:
-                pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else -d.pwr_produced)
-            pwr = min(pwr, setpoint, d.pwr_max)
+                pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else solar)
+            pwr = min(pwr, setpoint, headroom)
 
             # make sure we have devices in optimal working range
             if len(self.discharge) > 1 and i == 0 and d.state != DeviceState.SOCFULL:
                 self.pwr_low = 0 if (delta := d.discharge_start * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
                 pwr = 0 if self.pwr_low > d.discharge_optimal else pwr
 
-            setpoint -= await d.power_discharge(pwr)
+            setpoint -= max(0, await d.power_discharge(pwr + d.pwr_bypass) - d.pwr_bypass)
             dev_start += 1 if pwr != 0 and d.electricLevel.asInt + 3 < self.idle_lvlmax else 0
 
         # start idle device if needed


### PR DESCRIPTION
Fixes #1465. Maybe also fixes #1487, which looks like the same defect reported from a different hardware mix.

A `SOCFULL` device passing solar through to the home has that pass-through booked as non-dispatchable and removed from the setpoint (the `discharge_bypass` accumulation in `powerChanged`, then `setpoint -= self.discharge_bypass`). That part is correct — the power reaches the house regardless of what the controller does.

`power_discharge` then distributes the remaining setpoint as **absolute** output targets. A device already exporting `B` watts of bypass is commanded its share of the *reduced* setpoint, i.e. `B` watts short of what it should deliver. The bypass is never added back, so the device is told to output roughly what it is already doing, nothing changes, and the grid covers the difference indefinitely.

At steady state every device sits at its command, so `sum(homeOutput) == setpoint`. Substituting into `setpoint = p1 + sum(homeOutput) - discharge_bypass` gives a falsifiable prediction:

> **p1 == discharge_bypass**

This is what the fix does in detail:

- Record the per-device bypass (`pwr_bypass`) alongside `discharge_bypass`.
- Express the distribution in dispatchable power: `dispatch_limit` / `dispatch_produced`, and per device `headroom = pwr_max - pwr_bypass`, `solar = -pwr_produced - pwr_bypass`.
- Add the bypass back when issuing the absolute command, and credit only the dispatchable part against the setpoint.
- `dev_start` subtracts only the dispatchable solar.

The setpoint arithmetic in `powerChanged` is untouched, so the #1151 guarantee ("with no device charging and `p1 >= 0` the setpoint stays `>= 0`") still holds structurally. Where no device is bypassing, every `pwr_bypass` is 0, all new terms collapse to the originals, and the distribution is unchanged.

No new constants, no per-device timing state, no signature changes.
