### PR TITLE
Do not expect dispatchable power from a device reporting bypass

### DIFF
--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -137,6 +137,8 @@ class ZendureDevice(EntityDevice):
         self.maxSolar = 0
         self.pwr_max: int = 0
         self.pwr_produced: int = 0
+        # part of homeOutput the manager removes from its setpoint as non-dispatchable
+        self.pwr_bypass: int = 0
         self.actualKwh: float = 0.0
         self.state: DeviceState = DeviceState.OFFLINE
         self.exports_bypass: bool = True

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -597,16 +597,22 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         # Bypass already flows to the home and was subtracted from the setpoint, so it is
         # excluded from the capacities below and added back to the absolute command.
-        dispatch_limit = self.discharge_limit - self.discharge_bypass
+        # A device in bypass ignores an outputLimit above its pass-through, so it offers
+        # nothing dispatchable at all and another device has to cover the demand.
+        def dispatchable(d: ZendureDevice) -> int:
+            return 0 if d.byPass.asInt > 0 else max(0, d.pwr_max - d.pwr_bypass)
+
+        dispatch_limit = sum(dispatchable(d) for d in self.discharge)
         dispatch_produced = max(0, self.discharge_produced - self.discharge_bypass)
 
-        # distribute discharging devices, use produced power first, before adding another device
-        dev_start = max(0, setpoint - self.discharge_optimal * 2 - dispatch_produced) if setpoint > SmartMode.POWER_START else 0
+        # distribute discharging devices, use produced power first, before adding another device;
+        # start one as soon as the discharging devices run out of either optimal range or headroom
+        dev_start = max(0, setpoint - min(dispatch_limit, self.discharge_optimal * 2 + dispatch_produced)) if setpoint > SmartMode.POWER_START else 0
         solaronly = dispatch_produced >= setpoint
         limit = dispatch_produced if solaronly else dispatch_limit
         setpoint = min(limit, setpoint)
         for i, d in enumerate(sorted(self.discharge, key=lambda d: d.electricLevel.asInt, reverse=False)):
-            headroom = max(0, d.pwr_max - d.pwr_bypass)
+            headroom = dispatchable(d)
             solar = max(0, -d.pwr_produced - d.pwr_bypass)
 
             # Weight per device: pwr_max * SOC%. Devices with higher SOC get a

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -639,8 +639,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else solar)
             pwr = min(pwr, setpoint, headroom)
 
-            # make sure we have devices in optimal working range
-            if len(self.discharge) > 1 and i == 0 and d.state != DeviceState.SOCFULL:
+            # make sure we have devices in optimal working range; only park the lowest-SOC
+            # device when the other devices can actually absorb the setpoint. Bypassing peers
+            # contribute nothing dispatchable, so zeroing here would leave the demand uncovered
+            # and the device is restarted from idle on the next cycle - an endless start/stop cycle.
+            if i == 0 and d.state != DeviceState.SOCFULL and dispatch_limit - headroom >= setpoint:
                 self.pwr_low = 0 if (delta := d.discharge_start * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
                 pwr = 0 if self.pwr_low > d.discharge_optimal else pwr
 

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -427,6 +427,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         onlinekWh = 0
 
         for d in self.devices:
+            d.pwr_bypass = 0
             if await d.power_get():
                 # get power production
                 d.pwr_produced = min(0, d.batteryOutput.asInt + d.homeInput.asInt - d.batteryInput.asInt - d.homeOutput.asInt)
@@ -451,7 +452,8 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     # skew), and subtracting more than was added fabricates a phantom negative
                     # setpoint — the root cause of #1151.
                     if d.state == DeviceState.SOCFULL and d.exports_bypass:
-                        self.discharge_bypass += min(-d.pwr_produced, home)
+                        d.pwr_bypass = min(-d.pwr_produced, home)
+                        self.discharge_bypass += d.pwr_bypass
                     self.discharge_limit += d.fuseGrp.discharge_limit(d)
                     self.discharge_optimal += d.discharge_optimal
                     self.discharge_produced -= d.pwr_produced
@@ -593,12 +595,20 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             # SF 2400 may show more gridInputPower than offGridPower and will be recognized as charging, so set power to 10 instead of 0
             await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
 
+        # Bypass already flows to the home and was subtracted from the setpoint, so it is
+        # excluded from the capacities below and added back to the absolute command.
+        dispatch_limit = self.discharge_limit - self.discharge_bypass
+        dispatch_produced = max(0, self.discharge_produced - self.discharge_bypass)
+
         # distribute discharging devices, use produced power first, before adding another device
-        dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0
-        solaronly = self.discharge_produced >= setpoint
-        limit = self.discharge_produced if solaronly else self.discharge_limit
+        dev_start = max(0, setpoint - self.discharge_optimal * 2 - dispatch_produced) if setpoint > SmartMode.POWER_START else 0
+        solaronly = dispatch_produced >= setpoint
+        limit = dispatch_produced if solaronly else dispatch_limit
         setpoint = min(limit, setpoint)
         for i, d in enumerate(sorted(self.discharge, key=lambda d: d.electricLevel.asInt, reverse=False)):
+            headroom = max(0, d.pwr_max - d.pwr_bypass)
+            solar = max(0, -d.pwr_produced - d.pwr_bypass)
+
             # Weight per device: pwr_max * SOC%. Devices with higher SOC get a
             # larger share of the discharge power.
             # Guard against division by zero: discharge_weight can be 0 when all
@@ -612,23 +622,23 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                 pwr = int(setpoint / (len(self.discharge) - i))
             else:
                 pwr = 0
-            # SOCFULL devices should only pass through solar, not drain battery
-            if pwr < -d.pwr_produced and d.state == DeviceState.SOCFULL:
-                pwr = -d.pwr_produced
+            # SOCFULL devices should pass through at least their remaining solar
+            if pwr < solar and d.state == DeviceState.SOCFULL:
+                pwr = solar
             self.discharge_weight -= device_weight
 
             # adjust the limit, make sure we have 'enough' power to discharge
-            limit -= -d.pwr_produced if solaronly else d.pwr_max
+            limit -= solar if solaronly else headroom
             if limit < setpoint - pwr:
-                pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else -d.pwr_produced)
-            pwr = min(pwr, setpoint, d.pwr_max)
+                pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else solar)
+            pwr = min(pwr, setpoint, headroom)
 
             # make sure we have devices in optimal working range
             if len(self.discharge) > 1 and i == 0 and d.state != DeviceState.SOCFULL:
                 self.pwr_low = 0 if (delta := d.discharge_start * 1.5 - pwr) <= 0 else self.pwr_low + int(delta)
                 pwr = 0 if self.pwr_low > d.discharge_optimal else pwr
 
-            setpoint -= await d.power_discharge(pwr)
+            setpoint -= max(0, await d.power_discharge(pwr + d.pwr_bypass) - d.pwr_bypass)
             dev_start += 1 if pwr != 0 and d.electricLevel.asInt + 3 < self.idle_lvlmax else 0
 
         # start idle device if needed

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -597,10 +597,18 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
         # Bypass already flows to the home and was subtracted from the setpoint, so it is
         # excluded from the capacities below and added back to the absolute command.
-        # A device in bypass ignores an outputLimit above its pass-through, so it offers
-        # nothing dispatchable at all and another device has to cover the demand.
+        def capacity(d: ZendureDevice) -> int:
+            return max(0, d.pwr_max - d.pwr_bypass)
+
+        # When all discharging devices are in bypass and no idle device is left to start, command them out of bypass
+        no_alternative = (
+            setpoint > 0
+            and sum(capacity(d) for d in self.discharge if d.byPass.asInt == 0) == 0
+            and not any(d.state != DeviceState.SOCEMPTY for d in self.idle)
+        )
+
         def dispatchable(d: ZendureDevice) -> int:
-            return 0 if d.byPass.asInt > 0 else max(0, d.pwr_max - d.pwr_bypass)
+            return capacity(d) if no_alternative or d.byPass.asInt == 0 else 0
 
         dispatch_limit = sum(dispatchable(d) for d in self.discharge)
         dispatch_produced = max(0, self.discharge_produced - self.discharge_bypass)


### PR DESCRIPTION
Builds on #1559 and has to merge after or instead of it — it uses the `pwr_bypass` and `dispatch_limit` introduced there, so until #1559 lands this PR shows its commit (5bdceda7606ff528d7f499e8a84bdf5be25d1a23) too. Also related to #1465.

A device reporting bypass does not follow a raised `outputLimit`. `power_discharge` nevertheless counts `pwr_max - pwr_bypass` as available on it, hands it the whole setpoint and looks no further, so the demand stays uncovered while other devices sit idle. `dev_start` cannot correct for it either: its threshold is `discharge_optimal * 2`, which with a single device discharging is 600 W, so any smaller deficit is never acted on at all.

`dispatchable()` now reads the `byPass` sensor — the same test `power_charge` already uses to avoid stopping bypassing devices — and returns 0 for a device in bypass, so both `dispatch_limit` and the per-device `headroom` reflect that nothing more can be had from it. `dev_start` then fires when the discharging devices are out of headroom as well as when they leave their optimal range.

The two go together: the `dev_start` term does nothing until `dispatch_limit` reflects the bypass. A device that does not report the property keeps `byPass` at 0, so `dispatchable()` returns what it did before and the distribution is unchanged for it.
