### PR TITLE
Improve ZenSDK connectivity with configurable per-device IPs when mDNS or cloud IPs are unreliable

### DIFF
--- a/custom_components/zendure_ha/config_flow.py
+++ b/custom_components/zendure_ha/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import section
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 
@@ -15,14 +16,18 @@ from .api import Api, ApiError
 from .const import (
     CONF_APPTOKEN,
     CONF_AUTO_MQTT_USER,
+    CONF_LOCAL_IP_SECTION,
+    CONF_LOCAL_IPS,
     CONF_MQTTLOCAL,
     CONF_MQTTLOG,
     CONF_MQTTPORT,
     CONF_MQTTPSW,
     CONF_MQTTSERVER,
     CONF_MQTTUSER,
+    CONF_OVERWRITE_IP,
     CONF_P1METER,
     CONF_SIM,
+    CONF_USE_MDNS,
     CONF_WIFIPSW,
     CONF_WIFISSID,
     DOMAIN,
@@ -163,12 +168,49 @@ class ZendureConfigFlow(ConfigFlow, domain=DOMAIN):
 class ZendureOptionsFlowHandler(OptionsFlow):
     """Handles the options flow."""
 
+    def __init__(self) -> None:
+        """Initialize the options flow."""
+        self._devices: dict[str, str] = {}
+
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle options flow."""
         if user_input is not None:
-            data = self.config_entry.data | user_input
+            device_fields = self._devices
+            device_input = user_input.get(CONF_LOCAL_IP_SECTION, {})
+            local_ips: dict[str, str] = {}
+            if user_input.get(CONF_OVERWRITE_IP, False):
+                local_ips = {
+                    serial: device_input.get(serial, "").strip()
+                    for serial in device_fields
+                    if device_input.get(serial, "").strip()
+                }
+            data = self.config_entry.data | {
+                key: value
+                for key, value in user_input.items()
+                if key != CONF_LOCAL_IP_SECTION
+            }
+            data[CONF_LOCAL_IPS] = local_ips
             self.hass.config_entries.async_update_entry(self.config_entry, data=data)
             return self.async_create_entry(title="", data=data)
+
+        overwrite_ip = self.config_entry.data.get(CONF_OVERWRITE_IP, False)
+        configured_ips: dict[str, str] = {}
+        if overwrite_ip:
+            configured_ips = self.config_entry.data.get(CONF_LOCAL_IPS, {})
+        try:
+            devices = await Api.Connect(self.hass, dict(self.config_entry.data), False)
+        except ApiError as err:
+            _LOGGER.warning("Unable to retrieve device IPs for options flow: %s", err)
+            devices = None
+
+        self._devices = {
+            device["snNumber"]: configured_ips.get(device["snNumber"], device.get("ip", ""))
+            for device in (devices or {}).get("deviceList", [])
+            if device.get("snNumber")
+        }
+        self._devices.update(
+            {serial: ip for serial, ip in configured_ips.items() if serial not in self._devices}
+        )
 
         options_schema = vol.Schema(
             {
@@ -176,6 +218,25 @@ class ZendureOptionsFlowHandler(OptionsFlow):
                 vol.Required(CONF_MQTTLOG, default=self.config_entry.data[CONF_MQTTLOG]): bool,
                 vol.Optional(CONF_AUTO_MQTT_USER, default=self.config_entry.data.get(CONF_AUTO_MQTT_USER, False)): bool,
                 vol.Optional(CONF_SIM, default=self.config_entry.data.get(CONF_SIM, False)): bool,
+                vol.Optional(
+                    CONF_OVERWRITE_IP,
+                    default=overwrite_ip,
+                ): bool,
+                vol.Optional(
+                    CONF_USE_MDNS,
+                    default=self.config_entry.data.get(CONF_USE_MDNS, True),
+                ): bool,
+                vol.Required(CONF_LOCAL_IP_SECTION): section(
+                    vol.Schema(
+                        {
+                            vol.Optional(
+                                serial,
+                                description={"suggested_value": ip},
+                            ): str
+                            for serial, ip in self._devices.items()
+                        }
+                    )
+                ),
             }
         )
 

--- a/custom_components/zendure_ha/const.py
+++ b/custom_components/zendure_ha/const.py
@@ -18,6 +18,10 @@ CONF_MQTTPSW = "mqttpsw"
 CONF_WIFISSID = "wifissid"
 CONF_WIFIPSW = "wifipsw"
 CONF_AUTO_MQTT_USER = "auto_mqtt_user"
+CONF_LOCAL_IPS = "local_ips"
+CONF_LOCAL_IP_SECTION = "device_local_ips"
+CONF_OVERWRITE_IP = "overwrite_ip"
+CONF_USE_MDNS = "use_mdns"
 
 CONF_HAKEY = "C*dafwArEOXK"
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -123,7 +123,8 @@ class ZendureDevice(EntityDevice):
 
         self.mqtt: mqtt_client.Client | None = None
         self.zendure: mqtt_client.Client | None = None
-        self.ipAddress = definition.get("ip", "") if definition.get("ip", "") != "" else f"zendure-{definition['productModel'].replace(' ', '')}-{self.snNumber}.local"
+        self.ipAddress = definition.get("ip", "")
+        self.mdnsHost = f"zendure-{definition['productModel'].replace(' ', '')}-{self.snNumber}.local"
 
         self.topic_read = f"iot/{self.prodkey}/{self.deviceId}/properties/read"
         self.topic_write = f"iot/{self.prodkey}/{self.deviceId}/properties/write"
@@ -808,30 +809,55 @@ class ZendureZenSdk(ZendureDevice):
         else:
             self.mqttPublish(self.topic_write, command, self.mqtt)
 
+    def _http_hosts(self) -> list[str]:
+        hosts: list[str] = []
+        for host in (self.mdnsHost, self.ipAddress):
+            if host and host not in hosts:
+                hosts.append(host)
+        return hosts
+
     async def httpGet(self, url: str, key: str | None = None) -> dict[str, Any]:
-        try:
-            url = f"http://{self.ipAddress}/{url}"
-            response = await self.session.get(url, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
-            payload = json.loads(await response.text())
-            self.lastseen = datetime.now()
-            return payload if key is None else payload.get(key, {})
-        except Exception as e:
-            _LOGGER.error("%s for %s during httpGet%s", type(e).__name__, self.name, f": {e}" if str(e) else "!")
-            self.lastseen = datetime.min
+        last_error: Exception | None = None
+        for host in self._http_hosts():
+            try:
+                endpoint = f"http://{host}/{url}"
+                response = await self.session.get(endpoint, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
+                payload = json.loads(await response.text())
+                self.lastseen = datetime.now()
+                if host != self.ipAddress:
+                    self.ipAddress = host
+                return payload if key is None else payload.get(key, {})
+            except Exception as err:
+                last_error = err
+
+        err_name = type(last_error).__name__ if last_error is not None else "ConnectionError"
+        err_msg = f": {last_error}" if last_error and str(last_error) else "!"
+        _LOGGER.error("%s for %s during httpGet on %s%s", err_name, self.name, self._http_hosts(), err_msg)
+        self.lastseen = datetime.min
         return {}
 
     async def httpPost(self, url: str, command: Any) -> bool:
-        try:
-            self.httpid += 1
-            command["id"] = self.httpid
-            command["sn"] = self.snNumber
-            url = f"http://{self.ipAddress}/{url}"
-            await self.session.post(url, json=command, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
-        except Exception as e:
-            _LOGGER.error("%s for %s during httpPost%s", type(e).__name__, self.name, f": {e}" if str(e) else "!")
-            self.lastseen = datetime.min
-            return False
-        return True
+        self.httpid += 1
+        command["id"] = self.httpid
+        command["sn"] = self.snNumber
+
+        last_error: Exception | None = None
+        for host in self._http_hosts():
+            try:
+                endpoint = f"http://{host}/{url}"
+                await self.session.post(endpoint, json=command, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
+                self.lastseen = datetime.now()
+                if host != self.ipAddress:
+                    self.ipAddress = host
+                return True
+            except Exception as err:
+                last_error = err
+
+        err_name = type(last_error).__name__ if last_error is not None else "ConnectionError"
+        err_msg = f": {last_error}" if last_error and str(last_error) else "!"
+        _LOGGER.error("%s for %s during httpPost on %s%s", err_name, self.name, self._http_hosts(), err_msg)
+        self.lastseen = datetime.min
+        return False
 
 
 @dataclass

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -818,21 +818,20 @@ class ZendureZenSdk(ZendureDevice):
 
     async def httpGet(self, url: str, key: str | None = None) -> dict[str, Any]:
         last_error: Exception | None = None
-        for host in self._http_hosts():
+        hosts = self._http_hosts()
+        for host in hosts:
             try:
                 endpoint = f"http://{host}/{url}"
                 response = await self.session.get(endpoint, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
                 payload = json.loads(await response.text())
                 self.lastseen = datetime.now()
-                if host != self.ipAddress:
-                    self.ipAddress = host
                 return payload if key is None else payload.get(key, {})
             except Exception as err:
                 last_error = err
 
         err_name = type(last_error).__name__ if last_error is not None else "ConnectionError"
         err_msg = f": {last_error}" if last_error and str(last_error) else "!"
-        _LOGGER.error("%s for %s during httpGet on %s%s", err_name, self.name, self._http_hosts(), err_msg)
+        _LOGGER.error("%s for %s during httpGet on %s%s", err_name, self.name, hosts, err_msg)
         self.lastseen = datetime.min
         return {}
 
@@ -842,20 +841,19 @@ class ZendureZenSdk(ZendureDevice):
         command["sn"] = self.snNumber
 
         last_error: Exception | None = None
-        for host in self._http_hosts():
+        hosts = self._http_hosts()
+        for host in hosts:
             try:
                 endpoint = f"http://{host}/{url}"
                 await self.session.post(endpoint, json=command, headers=CONST_HEADER, timeout=CONST_TIMEOUT)
                 self.lastseen = datetime.now()
-                if host != self.ipAddress:
-                    self.ipAddress = host
                 return True
             except Exception as err:
                 last_error = err
 
         err_name = type(last_error).__name__ if last_error is not None else "ConnectionError"
         err_msg = f": {last_error}" if last_error and str(last_error) else "!"
-        _LOGGER.error("%s for %s during httpPost on %s%s", err_name, self.name, self._http_hosts(), err_msg)
+        _LOGGER.error("%s for %s during httpPost on %s%s", err_name, self.name, hosts, err_msg)
         self.lastseen = datetime.min
         return False
 

--- a/custom_components/zendure_ha/device.py
+++ b/custom_components/zendure_ha/device.py
@@ -125,6 +125,7 @@ class ZendureDevice(EntityDevice):
         self.zendure: mqtt_client.Client | None = None
         self.ipAddress = definition.get("ip", "")
         self.mdnsHost = f"zendure-{definition['productModel'].replace(' ', '')}-{self.snNumber}.local"
+        self.useMdns = definition.get("use_mdns", True)
 
         self.topic_read = f"iot/{self.prodkey}/{self.deviceId}/properties/read"
         self.topic_write = f"iot/{self.prodkey}/{self.deviceId}/properties/write"
@@ -811,7 +812,12 @@ class ZendureZenSdk(ZendureDevice):
 
     def _http_hosts(self) -> list[str]:
         hosts: list[str] = []
-        for host in (self.mdnsHost, self.ipAddress):
+        candidates = (
+            (self.mdnsHost, self.ipAddress)
+            if self.useMdns
+            else (self.ipAddress,)
+        )
+        for host in candidates:
             if host and host not in hosts:
                 hosts.append(host)
         return hosts

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -27,7 +27,10 @@ from homeassistant.loader import async_get_integration
 from .api import Api
 from .const import (
     CONF_AUTO_MQTT_USER,
+    CONF_LOCAL_IPS,
+    CONF_OVERWRITE_IP,
     CONF_P1METER,
+    CONF_USE_MDNS,
     DOMAIN,
     DeviceState,
     ManagerMode,
@@ -44,6 +47,7 @@ from .sensor import ZendureSensor
 SCAN_INTERVAL = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
+
 
 type ZendureConfigEntry = ConfigEntry[ZendureManager]
 
@@ -113,6 +117,12 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         self.globalSoc = ZendureSensor(self, "global_soc", None, "%", "battery", "measurement", 1)
 
         # load devices
+        config_data = self.config_entry.data
+        local_ips = (
+            config_data.get(CONF_LOCAL_IPS, {})
+            if config_data.get(CONF_OVERWRITE_IP, False)
+            else {}
+        )
         for dev in data["deviceList"]:
             try:
                 if (deviceId := dev["deviceKey"]) is None or (prodModel := dev["productModel"]) is None:
@@ -125,7 +135,18 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     continue
 
                 # create the device and mqtt server
-                device = init(self.hass, deviceId, dev.get("deviceName", prodModel), dev)
+                cloud_ip = dev.get("ip", "")
+                local_ip = local_ips.get(dev.get("snNumber", ""), "")
+                device_definition = dev | {
+                    "ip": local_ip or cloud_ip,
+                    CONF_USE_MDNS: config_data.get(CONF_USE_MDNS, True) and not local_ip,
+                }
+                device = init(
+                    self.hass,
+                    deviceId,
+                    dev.get("deviceName", prodModel),
+                    device_definition,
+                )
                 device.discharge_start = device.discharge_limit // 10
                 device.discharge_optimal = device.discharge_limit // 4
                 Api.devices[deviceId] = device

--- a/custom_components/zendure_ha/translations/en.json
+++ b/custom_components/zendure_ha/translations/en.json
@@ -55,9 +55,16 @@
         "data": {
           "p1meter": "P1 Sensor for smart matching",
           "mqttlog": "Log MQTT communication",
-          "auto_mqtt_user": "Automatically manage MQTT users"
+          "auto_mqtt_user": "Automatically manage MQTT users",
+          "use_mdns": "Use mDNS hostname for local devices",
+          "overwrite_ip": "Use manually configured IP addresses"
         },
-        "description": "Amend your options.",
+        "sections": {
+          "device_local_ips": {
+            "name": "Device local IP addresses"
+          }
+        },
+        "description": "Amend your options. Device local IP fields are prefilled from the cloud. Enable manual IP addresses to keep your entered values when the cloud IP changes; otherwise the cloud IP is refreshed automatically. Leave a field empty to use mDNS/cloud fallback.",
         "title": "Zendure Integration Options"
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,159 @@
+"""Tests for the Zendure config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.zendure_ha.api import Api
+from custom_components.zendure_ha.config_flow import ZendureOptionsFlowHandler
+from custom_components.zendure_ha.const import (
+    CONF_APPTOKEN,
+    CONF_LOCAL_IP_SECTION,
+    CONF_LOCAL_IPS,
+    CONF_MQTTLOG,
+    CONF_OVERWRITE_IP,
+    CONF_P1METER,
+    CONF_USE_MDNS,
+    DOMAIN,
+)
+
+
+async def test_options_flow_builds_and_saves_device_ip_fields(hass, monkeypatch) -> None:  # noqa: ANN001
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_APPTOKEN: "token",
+            CONF_P1METER: "sensor.power",
+            CONF_MQTTLOG: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    monkeypatch.setattr(
+        Api,
+        "Connect",
+        AsyncMock(
+            return_value={
+                "deviceList": [
+                    {"snNumber": "SN-ONE", "ip": "192.0.2.10"},
+                    {"snNumber": "SN-TWO", "ip": "192.0.2.11"},
+                ]
+            }
+        ),
+    )
+
+    flow = ZendureOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == "form"
+    section_schema = result["data_schema"].schema[CONF_LOCAL_IP_SECTION]
+    fields = section_schema.schema.schema
+    assert {field.schema for field in fields} == {"SN-ONE", "SN-TWO"}
+    suggested_ips = {
+        field.schema: field.description["suggested_value"] for field in fields
+    }
+    assert suggested_ips == {
+        "SN-ONE": "192.0.2.10",
+        "SN-TWO": "192.0.2.11",
+    }
+
+    result = await flow.async_step_init(
+        {
+            CONF_P1METER: "sensor.power",
+            CONF_MQTTLOG: False,
+            CONF_USE_MDNS: True,
+            CONF_LOCAL_IP_SECTION: {
+                "SN-ONE": "192.168.1.50",
+                "SN-TWO": "192.168.1.51",
+            },
+            CONF_OVERWRITE_IP: True,
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LOCAL_IPS] == {
+        "SN-ONE": "192.168.1.50",
+        "SN-TWO": "192.168.1.51",
+    }
+
+
+async def test_options_flow_prefers_saved_ips_over_cloud_ips(hass, monkeypatch) -> None:  # noqa: ANN001
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_APPTOKEN: "token",
+            CONF_P1METER: "sensor.power",
+            CONF_MQTTLOG: False,
+            CONF_LOCAL_IPS: {"SN-ONE": "192.168.1.50"},
+            CONF_OVERWRITE_IP: True,
+        },
+    )
+    entry.add_to_hass(hass)
+    monkeypatch.setattr(
+        Api,
+        "Connect",
+        AsyncMock(
+            return_value={
+                "deviceList": [
+                    {"snNumber": "SN-ONE", "ip": "192.0.2.10"},
+                ]
+            }
+        ),
+    )
+
+    flow = ZendureOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+    result = await flow.async_step_init()
+
+    section_schema = result["data_schema"].schema[CONF_LOCAL_IP_SECTION]
+    field = next(iter(section_schema.schema.schema))
+    assert field.description["suggested_value"] == "192.168.1.50"
+
+
+async def test_options_flow_uses_cloud_ips_when_overwrite_is_disabled(hass, monkeypatch) -> None:  # noqa: ANN001
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_APPTOKEN: "token",
+            CONF_P1METER: "sensor.power",
+            CONF_MQTTLOG: False,
+            CONF_LOCAL_IPS: {"SN-ONE": "192.168.1.50"},
+            CONF_OVERWRITE_IP: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    monkeypatch.setattr(
+        Api,
+        "Connect",
+        AsyncMock(
+            return_value={
+                "deviceList": [{"snNumber": "SN-ONE", "ip": "192.0.2.10"}]
+            }
+        ),
+    )
+
+    flow = ZendureOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+    result = await flow.async_step_init()
+
+    section_schema = result["data_schema"].schema[CONF_LOCAL_IP_SECTION]
+    field = next(iter(section_schema.schema.schema))
+    assert field.description["suggested_value"] == "192.0.2.10"
+
+    result = await flow.async_step_init(
+        {
+            CONF_P1METER: "sensor.power",
+            CONF_MQTTLOG: False,
+            CONF_USE_MDNS: True,
+            CONF_OVERWRITE_IP: False,
+            CONF_LOCAL_IP_SECTION: {"SN-ONE": "192.168.1.60"},
+        }
+    )
+
+    assert result["data"][CONF_LOCAL_IPS] == {}

--- a/tests/test_device_zensdk.py
+++ b/tests/test_device_zensdk.py
@@ -3,6 +3,27 @@
 from __future__ import annotations
 
 from custom_components.zendure_ha.const import SmartMode
+from custom_components.zendure_ha.device import ZendureZenSdk
+
+
+def _host_list(ip_address: str = "192.0.2.10", use_mdns: bool = True) -> list[str]:
+    device = object.__new__(ZendureZenSdk)
+    device.useMdns = use_mdns
+    device.mdnsHost = "device.local"
+    device.ipAddress = ip_address
+    return device._http_hosts()
+
+
+def test_http_hosts_prefers_manual_ip() -> None:
+    assert _host_list("192.0.2.20", use_mdns=False) == ["192.0.2.20"]
+
+
+def test_http_hosts_can_disable_mdns() -> None:
+    assert _host_list(use_mdns=False) == ["192.0.2.10"]
+
+
+def test_http_hosts_falls_back_from_mdns_to_cloud_ip() -> None:
+    assert _host_list() == ["device.local", "192.0.2.10"]
 
 
 def _last_props(device) -> dict:  # noqa: ANN001


### PR DESCRIPTION
Cloud deviceList metadata can contain stale private IP addresses after router or subnet changes. In that case, local ZenSDK polling and writes time out even though the device is reachable via its mDNS hostname.

This change makes local HTTP host selection resilient by trying mDNS first and using the cloud IP as a fallback.

Refs: #1583, #1594, #1615