### PR TITLE
fix(manager): don't let devices at a SoC limit mask a real grid deficit

### DIFF
--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -600,7 +600,13 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             await d.power_discharge(0 if max(0, d.pwr_offgrid) == 0 else 10)
 
         # distribute discharging devices, use produced power first, before adding another device
-        dev_start = max(0, setpoint - self.discharge_optimal * 2 - self.discharge_produced) if setpoint > SmartMode.POWER_START else 0
+        # Only *dispatchable* capacity may offset the setpoint. A device at either SoC limit has none:
+        # SOCFULL cannot supply from its battery (its bypass was already netted out in powerChanged),
+        # SOCEMPTY is pinned at minSoc. Crediting them cancels a real deficit and the grid pays instead.
+        blocked = (DeviceState.SOCFULL, DeviceState.SOCEMPTY)
+        blocked_optimal = sum(d.discharge_optimal for d in self.discharge if d.state in blocked)
+        dispatchable = (self.discharge_optimal - blocked_optimal) * 2 + (self.discharge_produced - self.discharge_bypass)
+        dev_start = max(0, setpoint - dispatchable) if setpoint > SmartMode.POWER_START else 0
         solaronly = self.discharge_produced >= setpoint
         limit = self.discharge_produced if solaronly else self.discharge_limit
         setpoint = min(limit, setpoint)
@@ -628,6 +634,11 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             if limit < setpoint - pwr:
                 pwr = max(setpoint - limit, 0 if d.state != DeviceState.SOCFULL else -d.pwr_produced)
             pwr = min(pwr, setpoint, d.pwr_max)
+
+            # Re-apply the SOCFULL floor: the min() above clamps to a setpoint that already had this
+            # device's bypass removed. Commanding it below its own production only curtails the PV.
+            if d.state == DeviceState.SOCFULL:
+                pwr = max(pwr, min(-d.pwr_produced, d.pwr_max))
 
             # make sure we have devices in optimal working range
             if len(self.discharge) > 1 and i == 0 and d.state != DeviceState.SOCFULL:

--- a/tests/test_manager_dispatch.py
+++ b/tests/test_manager_dispatch.py
@@ -62,6 +62,7 @@ def _make_manager_harness() -> ZendureManager:
     manager.charge_last = datetime.min
     manager.charge_weight = 0
     manager.discharge = []
+    manager.discharge_bypass = 0
     manager.discharge_produced = 0
     manager.discharge_limit = 0
     manager.discharge_optimal = 0
@@ -108,3 +109,125 @@ async def test_power_charge_first_call_primes_hysteria_and_forces_zero_setpoint(
     assert manager.charge_time == now + timedelta(seconds=2)
     assert manager.pwr_low == 0
     assert manager.operationstate.values == [ManagerState.IDLE.value]
+
+
+def _make_socfull_bypass_scenario() -> tuple[ZendureManager, _FakeDevice, _FakeDevice, _FakeDevice]:
+    """Real-world capture: 3-device fleet, 2026-08-19 15:30 CEST.
+
+    One SOCFULL Hyper 2000 bypasses 590 W of its own solar to the home. The two
+    other devices are charging from their *own DC solar* (not from the home bus),
+    so homeInput/homeOutput are both 0 and powerChanged() files them under `idle`,
+    not `charge` -- nothing in power_discharge stops their charging.
+
+    House load 894 W, total PV 1172 W, 304 W bought from the grid.
+    """
+    manager = _make_manager_harness()
+
+    full = _FakeDevice(pwr_max=1200, electric_level=100, state=DeviceState.SOCFULL)
+    full.pwr_produced = -590
+    full.discharge_start = 120
+    full.discharge_optimal = 300
+
+    idle_high = _FakeDevice(pwr_max=1200, electric_level=93)
+    idle_high.pwr_produced = -398
+    idle_high.discharge_start = 120
+    idle_high.discharge_optimal = 300
+
+    idle_low = _FakeDevice(pwr_max=800, electric_level=59)
+    idle_low.pwr_produced = -145
+    idle_low.discharge_start = 80
+    idle_low.discharge_optimal = 200
+
+    manager.discharge = [full]
+    manager.discharge_limit = 1200
+    manager.discharge_optimal = full.discharge_optimal
+    manager.discharge_produced = 590
+    manager.discharge_bypass = 590
+    manager.discharge_weight = full.pwr_max * full.electricLevel.asInt
+    manager.idle = [idle_high, idle_low]
+    manager.idle_lvlmax = 93
+    manager.idle_lvlmin = 59
+    return manager, full, idle_high, idle_low
+
+
+async def test_socfull_bypass_is_never_commanded_below_its_production() -> None:
+    """A SOCFULL device's solar bypass is non-dispatchable. Commanding it below
+    what it already produces curtails PV and pushes the deficit onto the grid.
+    """
+    manager, full, _idle_high, _idle_low = _make_socfull_bypass_scenario()
+
+    await manager.power_discharge(304)
+
+    assert full.discharge_calls, "the bypassing device got no command at all"
+    assert full.discharge_calls[-1] >= 590, (
+        f"SOCFULL device commanded {full.discharge_calls[-1]} W while already producing 590 W: "
+        "its solar gets curtailed and the grid import grows"
+    )
+
+
+async def test_socfull_bypass_does_not_mask_a_real_deficit_from_idle_devices() -> None:
+    """304 W of real deficit remains after the bypass. The SOCFULL device cannot
+    serve it (battery full), so an idle device must be started.
+    """
+    manager, _full, idle_high, idle_low = _make_socfull_bypass_scenario()
+
+    await manager.power_discharge(304)
+
+    assert idle_high.discharge_calls or idle_low.discharge_calls, (
+        "no idle device was started: the 304 W deficit stays on the grid even though "
+        "two devices with charged batteries and their own solar are sitting idle"
+    )
+
+
+def _make_socempty_scenario() -> tuple[ZendureManager, _FakeDevice, _FakeDevice, _FakeDevice]:
+    """Real-world capture: same fleet, 2026-08-20 09:06 CEST, the mirror case.
+
+    Both Hyper 2000 sit at minSoc (5%) -> SOCEMPTY: they still pass their own solar
+    to the home (146 W and 65 W) so powerChanged() files them under `discharge`,
+    but their batteries cannot supply anything. The SolarFlow is at 7%, has real
+    reserve left, and is charging from its own DC solar -> filed under `idle`.
+
+    House 370 W of target output, 211 W of solar passing through, 159 W bought.
+    """
+    manager = _make_manager_harness()
+
+    empty_a = _FakeDevice(pwr_max=1200, electric_level=5, state=DeviceState.SOCEMPTY)
+    empty_a.pwr_produced = -146
+    empty_a.discharge_start = 120
+    empty_a.discharge_optimal = 300
+
+    empty_b = _FakeDevice(pwr_max=1200, electric_level=5, state=DeviceState.SOCEMPTY)
+    empty_b.pwr_produced = -65
+    empty_b.discharge_start = 120
+    empty_b.discharge_optimal = 300
+
+    reserve = _FakeDevice(pwr_max=800, electric_level=7)
+    reserve.pwr_produced = -55
+    reserve.discharge_start = 80
+    reserve.discharge_optimal = 200
+
+    manager.discharge = [empty_a, empty_b]
+    manager.discharge_limit = 2400
+    manager.discharge_optimal = empty_a.discharge_optimal + empty_b.discharge_optimal
+    manager.discharge_produced = 211
+    manager.discharge_bypass = 0
+    manager.discharge_weight = sum(d.pwr_max * d.electricLevel.asInt for d in manager.discharge)
+    manager.idle = [reserve]
+    manager.idle_lvlmax = 7
+    manager.idle_lvlmin = 7
+    return manager, empty_a, empty_b, reserve
+
+
+async def test_socempty_devices_do_not_mask_a_real_deficit() -> None:
+    """Devices pinned at minSoc have no dispatchable headroom either. Crediting
+    them with discharge_optimal cancels the 159 W deficit, so the one device that
+    still holds usable charge is never started and the grid pays instead.
+    """
+    manager, _a, _b, reserve = _make_socempty_scenario()
+
+    await manager.power_discharge(370)
+
+    assert reserve.discharge_calls, (
+        "the only device with charge left was not started: the 159 W deficit stays on "
+        "the grid while two SOCEMPTY devices are credited with 600 W of phantom headroom"
+    )


### PR DESCRIPTION
In MATCHING mode with a mixed-SoC fleet, `dev_start` in power_discharge() credits every device in `self.discharge` with `discharge_optimal` of headroom, and subtracts the whole of `discharge_produced`. Two of those inputs are not dispatchable:

- A SOCFULL device cannot supply anything from its battery, and its solar bypass was already netted out of the setpoint in powerChanged() — subtracting it again in `discharge_produced` double-counts it.
- A SOCEMPTY device is pinned at minSoc. It still lands in `self.discharge` because it passes its own solar through (homeOutput > 0), but it has no headroom either.

Either one cancels the real deficit, `dev_start` stays 0, no idle device is started, and the grid covers the gap indefinitely. Devices charging from their own DC solar are filed under `idle` (homeInput == homeOutput == 0), so the "stop charging devices" loop never touches them — starting an idle device is the only lever, and it was blocked.

Separately, `pwr = min(pwr, setpoint, d.pwr_max)` undid the SOCFULL floor set a few lines above, commanding a bypassing device below what it already produces. That only curtails its PV and grows the import, then rebounds next cycle — visible as the manager state flipping between charge/discharge/idle dozens of times per hour.

Measured on a 3-device fleet (2x Hyper 2000 + SolarFlow 800 Plus, local MQTT, Shelly Pro 3EM as P1):

  2026-08-19 15:30 - one Hyper at 100% bypassing 590 W, the two others charging 543 W
  from their own solar, house 894 W, total PV 1172 W, 304 W bought from the grid. PV
  exceeded the load by 278 W throughout.

  2026-08-20 09:06 - both Hypers at minSoc passing 211 W of solar through, SolarFlow at
  7% with reserve left but charging, 159 W bought. After the fix, same solar and same
  load 11 minutes later: SolarFlow delivering 136 W, grid at -11 W.

Three scenario tests added to tests/test_manager_dispatch.py, using the existing harness. Each one fails on the code before this change and passes after it. I ran the file with the pinned test stack (pytest-homeassistant-custom-component==0.13.347, pytest==9.0.3, pytest-asyncio==1.4.0) against homeassistant==2026.7.3: 6 passed — the three new tests plus the three pre-existing ones in that file, unchanged. Note that this pin of pytest-homeassistant-custom-component requires Python 3.14, it does not resolve on 3.13.

Not changed here: SOCFULL devices still take a weighted share of the dispatchable setpoint via `discharge_weight`, so the devices that can actually discharge converge slowly. And power_charge() has the mirror-image issue with `charge_optimal` counting SOCFULL devices. Both looked like design calls rather than bugs, so they are left alone.