### PR TITLE
Make Zendure switch entities persistent across restarts

### DIFF
--- a/custom_components/zendure_ha/switch.py
+++ b/custom_components/zendure_ha/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.template import Template
 
 from .entity import EntityDevice, EntityZendure
@@ -23,7 +24,7 @@ async def async_setup_entry(_hass: HomeAssistant, _config_entry: ConfigEntry, as
     ZendureSwitch.add = async_add_entities
 
 
-class ZendureSwitch(EntityZendure, SwitchEntity):
+class ZendureSwitch(EntityZendure, SwitchEntity, RestoreEntity):
     add: AddEntitiesCallback
 
     def __init__(
@@ -45,6 +46,16 @@ class ZendureSwitch(EntityZendure, SwitchEntity):
         if value is not None:
             self._attr_is_on = value
         self.add([self])
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the switch state and apply it to the device."""
+        await super().async_added_to_hass()
+        if state := await self.async_get_last_state():
+            self._attr_is_on = state.state == "on"
+            if asyncio.iscoroutinefunction(self._onwrite):
+                await self._onwrite(self, int(self._attr_is_on))
+            else:
+                self._onwrite(self, int(self._attr_is_on))
 
     def update_value(self, value: Any) -> bool:
         try:


### PR DESCRIPTION
### Summary
Make the shared ZendureSwitch implementation inherit from Home Assistant’s RestoreEntity, allowing switch states to be restored after Home Assistant restarts.

### Changes
- Add RestoreEntity support to the existing ZendureSwitch class.
- Restore the previous on or off state when a switch entity is added to Home Assistant.
- Reapply the restored value through the switch’s existing callback.
- Keep the behavior in the existing shared switch class so all Zendure switch entities benefit from state restoration.

### Behavior 
**Before:** 
- Switch entities were initialized with their configured default state after a Home Assistant restart.
- A switch that had previously been enabled could return to its default state.

**After:**
- Home Assistant restores the last known state of each switch.
- The restored state is applied through the existing switch callback.
- Switch entities retain their state across Home Assistant restarts.